### PR TITLE
feat: image version bump and template files upgrade

### DIFF
--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflowkatib/katib-controller:v0.12.0
+    upstream-source: docker.io/kubeflowkatib/katib-controller:v0.14.0-rc.0
 provides:
   katib-controller:
     interface: http

--- a/charms/katib-controller/src/crds.yaml
+++ b/charms/katib-controller/src/crds.yaml
@@ -38,48 +38,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: suggestions.kubeflow.org
-spec:
-  group: kubeflow.org
-  scope: Namespaced
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Type
-          type: string
-          jsonPath: .status.conditions[-1:].type
-        - name: Status
-          type: string
-          jsonPath: .status.conditions[-1:].status
-        - name: Requested
-          type: string
-          jsonPath: .spec.requests
-        - name: Assigned
-          type: string
-          jsonPath: .status.suggestionCount
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    kind: Suggestion
-    singular: suggestion
-    plural: suggestions
-    categories:
-      - all
-      - kubeflow
-      - katib
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
   name: trials.kubeflow.org
 spec:
   group: kubeflow.org

--- a/charms/katib-controller/src/early-stopping.json
+++ b/charms/katib-controller/src/early-stopping.json
@@ -1,5 +1,5 @@
 {
   "medianstop": {
-    "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.12.0"
+    "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.14.0-rc.0"
   }
 }

--- a/charms/katib-controller/src/metrics-collector-sidecar.json
+++ b/charms/katib-controller/src/metrics-collector-sidecar.json
@@ -1,12 +1,12 @@
 {
   "StdOut": {
-    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0"
+    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
   },
   "File": {
-    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0"
+    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
   },
   "TensorFlowEvent": {
-    "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.12.0",
+    "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.14.0-rc.0",
     "resources": {
       "limits": {
         "memory": "1Gi"

--- a/charms/katib-controller/src/suggestion.json
+++ b/charms/katib-controller/src/suggestion.json
@@ -1,30 +1,30 @@
 {
   "random": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
   },
   "tpe": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
   },
   "grid": {
-    "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.14.0-rc.0"
   },
   "hyperband": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.14.0-rc.0"
   },
   "bayesianoptimization": {
-    "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.14.0-rc.0"
   },
   "cmaes": {
-    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
   },
   "sobol": {
-    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
   },
   "multivariate-tpe": {
-    "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.14.0-rc.0"
   },
   "enas": {
-    "image": "docker.io/kubeflowkatib/suggestion-enas:v0.12.0",
+    "image": "docker.io/kubeflowkatib/suggestion-enas:v0.14.0-rc.0",
     "resources": {
       "limits": {
         "memory": "200Mi"
@@ -32,6 +32,6 @@
     }
   },
   "darts": {
-    "image": "docker.io/kubeflowkatib/suggestion-darts:v0.12.0"
+    "image": "docker.io/kubeflowkatib/suggestion-darts:v0.14.0-rc.0"
   }
 }

--- a/charms/katib-controller/src/webhooks.yaml
+++ b/charms/katib-controller/src/webhooks.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -6,9 +7,8 @@ webhooks:
   - name: validator.experiment.katib.kubeflow.org
     sideEffects: None
     failurePolicy: Ignore
-    # TODO (andreyvelich): Migrate to v1 ?
     admissionReviewVersions:
-      - v1beta1
+      - v1
     clientConfig:
       caBundle: Cg==
       service:
@@ -35,7 +35,7 @@ webhooks:
     sideEffects: None
     failurePolicy: Ignore
     admissionReviewVersions:
-      - v1beta1
+      - v1
     clientConfig:
       caBundle: Cg==
       service:
@@ -56,7 +56,7 @@ webhooks:
     sideEffects: None
     failurePolicy: Ignore
     admissionReviewVersions:
-      - v1beta1
+      - v1
     clientConfig:
       caBundle: Cg==
       service:


### PR DESCRIPTION
This PR introduces the following:
* feat: update template files to match 0.14.0-rc0 release
* feat: version bump katib-controller image 0.12.0->0.14.0.rc0