### PR TITLE
feat: dynamic sidebar content

### DIFF
--- a/charms/katib-ui/config.yaml
+++ b/charms/katib-ui/config.yaml
@@ -3,15 +3,4 @@ options:
     type: int
     default: 8080
     description: HTTP port
-  sidebar-text:
-    type: string
-    default: Experiments (AutoML)
-    description: Label text in dashboard sidebar
-  sidebar-icon:
-    type: string
-    default: kubeflow:katib
-    description: Icon name to be used in dashboard sidebar
-  sidebar-link:
-    type: string
-    default: /katib/
-    description: Url path associated with the sidebar element
+

--- a/charms/katib-ui/config.yaml
+++ b/charms/katib-ui/config.yaml
@@ -3,3 +3,15 @@ options:
     type: int
     default: 8080
     description: HTTP port
+  sidebar-text:
+    type: string
+    default: Experiments (AutoML)
+    description: Label text in dashboard sidebar
+  sidebar-icon:
+    type: string
+    default: kubeflow:katib
+    description: Icon name to be used in dashboard sidebar
+  sidebar-link:
+    type: string
+    default: /katib/
+    description: Url path associated with the sidebar element

--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -22,6 +22,6 @@ requires:
 provides:
   katib-ui:
     interface: http
-  sidepanel:
-    interface: sidepanel
+  sidebar:
+    interface: sidebar
     optional: true

--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -22,3 +22,6 @@ requires:
 provides:
   katib-ui:
     interface: http
+  sidepanel:
+    interface: sidepanel
+    optional: true

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -42,6 +42,10 @@ class Operator(CharmBase):
         self.framework.observe(
             self.on.sidebar_relation_joined, self._on_sidebar_relation_joined
         )
+        self.framework.observe(
+            self.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
 
     def set_pod_spec(self, event):
         try:
@@ -157,6 +161,7 @@ class Operator(CharmBase):
                     [
                         {
                             "app": self.app.name,
+                            "position": 5,
                             "type": "item",
                             "link": "/katib/",
                             "text": "Experiments (AutoML)",
@@ -166,6 +171,11 @@ class Operator(CharmBase):
                 )
             }
         )
+
+    def _on_sidebar_relation_departed(self, event):
+        if not self.unit.is_leader():
+            return
+        event.relation.data[self.app].update({"config": json.dumps([])})
 
 
 if __name__ == "__main__":

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -154,13 +154,15 @@ class Operator(CharmBase):
         event.relation.data[self.app].update(
             {
                 "config": json.dumps(
-                    {
-                        "app": self.app.name,
-                        "type": "item",
-                        "link": self.model.config["sidebar-link"],
-                        "text": self.model.config["sidebar-text"],
-                        "icon": self.model.config["sidebar-icon"],
-                    }
+                    [
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "link": "/katib/",
+                            "text": "Experiments (AutoML)",
+                            "icon": "kubeflow:katib",
+                        }
+                    ]
                 )
             }
         )


### PR DESCRIPTION
Related to this [jira task](https://warthogs.atlassian.net/browse/KF-567?atlOrigin=eyJpIjoiN2M3MjQwZmY2NzEwNGQwMTkzYThkZTNhMzU0YmFlNmUiLCJwIjoiaiJ9) and this [feature](https://github.com/canonical/kubeflow-dashboard-operator/issues/8)

In `kubeflow-dashboard-operator` there is a `sidebar` relation with the `src/extra_config.json`. In order to add element to the sidebar proper relation needs to be established. After the relation is set, charms fills the config for given app-name from `src/extra_config.json` and reloads the configmap. Currently supporting (juju application names)

- **katib-ui** for katib
- **tensorboards-web-app** for tesorboard

Sidebar element is removed after the relation is broken.