### PR TITLE
Add suggestions.kubeflow.org CRD

### DIFF
--- a/charms/katib-controller/src/crds.yaml
+++ b/charms/katib-controller/src/crds.yaml
@@ -70,3 +70,45 @@ spec:
       - all
       - kubeflow
       - katib
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: suggestions.kubeflow.org
+spec:
+  group: kubeflow.org
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          jsonPath: .status.conditions[-1:].type
+        - name: Status
+          type: string
+          jsonPath: .status.conditions[-1:].status
+        - name: Requested
+          type: string
+          jsonPath: .spec.requests
+        - name: Assigned
+          type: string
+          jsonPath: .status.suggestionCount
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Suggestion
+    singular: suggestion
+    plural: suggestions
+    categories:
+      - all
+      - kubeflow
+      - katib


### PR DESCRIPTION
For katib 0.14 we seem to be missing the suggestions.kubeflow.org CRD this commit adds the CRD to crds.yaml and it will be applied through pod spec like the others.