### PR TITLE
fix: pass ca.crt to webhooks and make it available in volume mount

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -85,6 +85,8 @@ jobs:
         cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
         sg microk8s -c 'juju bootstrap microk8s uk8s'
         juju add-model kubeflow
+        # Katib requires the namespace to have certain labels for metrics collection
+        sg microk8s -c 'kubectl label namespace default katib.kubeflow.org/metrics-collector-injection=enabled'
         juju bundle deploy --build --destructive-mode --serial
         juju wait -wvt 600
 

--- a/charms/katib-controller/src/webhooks.yaml
+++ b/charms/katib-controller/src/webhooks.yaml
@@ -6,11 +6,11 @@ metadata:
 webhooks:
   - name: validator.experiment.katib.kubeflow.org
     sideEffects: None
-    failurePolicy: Ignore
+    failurePolicy: Fail
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
+      caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
         namespace: kubeflow
@@ -33,11 +33,11 @@ metadata:
 webhooks:
   - name: defaulter.experiment.katib.kubeflow.org
     sideEffects: None
-    failurePolicy: Ignore
+    failurePolicy: Fail
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
+      caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
         namespace: kubeflow
@@ -54,11 +54,11 @@ webhooks:
           - experiments
   - name: mutator.pod.katib.kubeflow.org
     sideEffects: None
-    failurePolicy: Ignore
+    failurePolicy: Fail
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
+      caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
         namespace: kubeflow

--- a/examples/v1beta1/hp-tuning/random.yaml
+++ b/examples/v1beta1/hp-tuning/random.yaml
@@ -1,7 +1,6 @@
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:
-  namespace: kubeflow
   name: random
 spec:
   objective:


### PR DESCRIPTION
There was a missing certificate file in the operator's volumeConfig,
and both admission and mutating webhooks were not receiving any caBundle.
This commit adds the missing certificate to enable the correct behaviour
of the katib-controller and the resources that depend on it.

NOTE: this commit must be backported to track/0.14

Fixes: #13, #19