### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -18,8 +18,44 @@ resources:
 requires:
   ingress:
     interface: ingress
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
 provides:
   katib-ui:
     interface: http


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).