### PR TITLE
katib-controller/ui manifest upgrade 0.14.0 -> 0.15.0.rc.0

### DIFF
--- a/charms/katib-controller/src/crds.yaml
+++ b/charms/katib-controller/src/crds.yaml
@@ -5,35 +5,35 @@ metadata:
   name: experiments.kubeflow.org
 spec:
   group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Experiment
+    plural: experiments
+    singular: experiment
   scope: Namespaced
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Type
-          type: string
-          jsonPath: .status.conditions[-1:].type
-        - name: Status
-          type: string
-          jsonPath: .status.conditions[-1:].status
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    kind: Experiment
-    singular: experiment
-    plural: experiments
-    categories:
-      - all
-      - kubeflow
-      - katib
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[-1:].status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -41,35 +41,35 @@ metadata:
   name: trials.kubeflow.org
 spec:
   group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Trial
+    plural: trials
+    singular: trial
   scope: Namespaced
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Type
-          type: string
-          jsonPath: .status.conditions[-1:].type
-        - name: Status
-          type: string
-          jsonPath: .status.conditions[-1:].status
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    kind: Trial
-    singular: trial
-    plural: trials
-    categories:
-      - all
-      - kubeflow
-      - katib
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[-1:].status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -77,38 +77,38 @@ metadata:
   name: suggestions.kubeflow.org
 spec:
   group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Suggestion
+    plural: suggestions
+    singular: suggestion
   scope: Namespaced
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Type
-          type: string
-          jsonPath: .status.conditions[-1:].type
-        - name: Status
-          type: string
-          jsonPath: .status.conditions[-1:].status
-        - name: Requested
-          type: string
-          jsonPath: .spec.requests
-        - name: Assigned
-          type: string
-          jsonPath: .status.suggestionCount
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    kind: Suggestion
-    singular: suggestion
-    plural: suggestions
-    categories:
-      - all
-      - kubeflow
-      - katib
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[-1:].status
+      name: Status
+      type: string
+    - jsonPath: .spec.requests
+      name: Requested
+      type: string
+    - jsonPath: .status.suggestionCount
+      name: Assigned
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charms/katib-controller/src/defaultTrialTemplate.yaml
+++ b/charms/katib-controller/src/defaultTrialTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/mxnet-mnist:latest
+          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
           command:
             - "python3"
             - "/opt/mxnet-mnist/mnist.py"

--- a/charms/katib-controller/src/early-stopping.json
+++ b/charms/katib-controller/src/early-stopping.json
@@ -1,5 +1,5 @@
 {
   "medianstop": {
-    "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.0"
   }
 }

--- a/charms/katib-controller/src/enasCPUTemplate.yaml
+++ b/charms/katib-controller/src/enasCPUTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:latest
+          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
           command:
             - python3
             - -u

--- a/charms/katib-controller/src/metrics-collector-sidecar.json
+++ b/charms/katib-controller/src/metrics-collector-sidecar.json
@@ -1,12 +1,12 @@
 {
   "StdOut": {
-    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
   },
   "File": {
-    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
   },
   "TensorFlowEvent": {
-    "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.14.0-rc.0",
+    "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.0",
     "resources": {
       "limits": {
         "memory": "1Gi"

--- a/charms/katib-controller/src/pytorchJobTemplate.yaml
+++ b/charms/katib-controller/src/pytorchJobTemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: "kubeflow.org/v1"
+apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 spec:
   pytorchReplicaSpecs:
@@ -9,8 +9,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:latest
-              imagePullPolicy: Always
+              image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
               command:
                 - "python3"
                 - "/opt/pytorch-mnist/mnist.py"
@@ -24,8 +23,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:latest
-              imagePullPolicy: Always
+              image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
               command:
                 - "python3"
                 - "/opt/pytorch-mnist/mnist.py"

--- a/charms/katib-controller/src/suggestion.json
+++ b/charms/katib-controller/src/suggestion.json
@@ -1,30 +1,30 @@
 {
   "random": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
   },
   "tpe": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
   },
   "grid": {
-    "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
   },
   "hyperband": {
-    "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.0"
   },
   "bayesianoptimization": {
-    "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.0"
   },
   "cmaes": {
-    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
   },
   "sobol": {
-    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
   },
   "multivariate-tpe": {
-    "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
   },
   "enas": {
-    "image": "docker.io/kubeflowkatib/suggestion-enas:v0.14.0-rc.0",
+    "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.0",
     "resources": {
       "limits": {
         "memory": "200Mi"
@@ -32,6 +32,19 @@
     }
   },
   "darts": {
-    "image": "docker.io/kubeflowkatib/suggestion-darts:v0.14.0-rc.0"
+    "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.0"
+  },
+  "pbt": {
+    "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.0",
+    "persistentVolumeClaimSpec": {
+      "accessModes": [
+        "ReadWriteMany"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "5Gi"
+        }
+      }
+    }
   }
 }

--- a/charms/katib-ui/src/templates/auth_manifests.yaml.j2
+++ b/charms/katib-ui/src/templates/auth_manifests.yaml.j2
@@ -18,6 +18,24 @@ rules:
       - suggestions
     verbs:
       - "*"
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - list
+  - apiGroups:
+    - ""
+    resources:
+    - pods/log
+    verbs:
+    - get
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This PR updates the manifest and json files to match the upstream RC. 

This PR is based on kubeflow/manifests#2367, thus all manifests were rendered using the following command on that branch:

`kustomize build apps/katib/upstream/installs/katib-with-kubeflow | tee katib.manifests`