### PR TITLE
fix: bump serialized-data-interface to 0.4.0 on track/0.14

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         charm:
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -53,7 +53,7 @@ jobs:
 
   build:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out repo

--- a/charms/katib-ui/requirements.txt
+++ b/charms/katib-ui/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.2.0
 oci-image==1.0.0
-serialized-data-interface==0.2.2
+serialized-data-interface==0.4.0

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -50,7 +50,6 @@ class Operator(CharmBase):
 
     def set_pod_spec(self, event):
         try:
-
             self._check_leader()
 
             interfaces = self._get_interfaces()


### PR DESCRIPTION
Implements the fix described in bundle-kubeflow#541

Notes to reviewers about CI:
* failures in library checks can be ignored (this is patching an old release anyway - we will not bump the libraries here)
* failures in publish are expected - our automated publishing on `pull_request` does not work when opening PRs against `track/*` branches