### PR TITLE
tests: pin python-libjuju<3.1 to avoid unsupported version errors

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-juju
+juju<3.1
 pytest
 pyyaml
 lightkube


### PR DESCRIPTION
Apparently the juju agent 2.9.34 is not compatible with pythonlib-juju 3.1, causing the following error:
juju.errors.JujuConnectionError: juju server-version 2.9.34 not supported To avoid this, we have to pin to a version below 3.1.