### PR TITLE
fix: Use root for legacy DB connection

### DIFF
--- a/charms/katib-db-manager/src/charm.py
+++ b/charms/katib-db-manager/src/charm.py
@@ -241,7 +241,8 @@ class KatibDBManagerOperator(CharmBase):
             # retrieve database data from relation data
             # this also validates the expected data by means of KeyError exception
             db_data["db_type"] = "mysql"
-            db_data["db_username"] = relation_data["user"]
+            # in case of `mysql` relation older charms operated with hardcoded `root` username
+            db_data["db_username"] = "root"
             db_data["db_password"] = relation_data["root_password"]
             db_data["katib_db_host"] = relation_data["host"]
             db_data["katib_db_port"] = relation_data["port"]


### PR DESCRIPTION
**NOTE:** *This PR description only contains information related to code changes and testing, if required. All detailed information about problem statement, design, implementation, technical discussions, etc. is tracked in corresponding Github issue indicated below. This will ensure that important information is reliably recorded and tracked and not scattered across PR(s).*

**Details**
Refer to the following Github issue for more information on fix that this PR is related to:
https://github.com/canonical/katib-operators/issues/85

Summary of changes:
- Modified code to use root user for legacy DB connection.