### PR TITLE
build: bump juju 2.9.44.0, sdi->0.7.0, pyyaml->6.0.1

### DIFF
--- a/charms/katib-controller/requirements.txt
+++ b/charms/katib-controller/requirements.txt
@@ -8,7 +8,7 @@ oci-image==1.0.0
     # via -r requirements.in
 ops==2.3.0
     # via -r requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via ops
 websocket-client==1.5.3
     # via ops

--- a/charms/katib-db-manager/requirements.txt
+++ b/charms/katib-db-manager/requirements.txt
@@ -46,7 +46,7 @@ ops==2.3.0
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops

--- a/charms/katib-ui/requirements.txt
+++ b/charms/katib-ui/requirements.txt
@@ -61,7 +61,7 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops
@@ -72,7 +72,7 @@ ruamel-yaml==0.17.31
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r requirements.in
 sniffio==1.3.0
     # via

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-juju<3.1
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest
 pyyaml
 lightkube

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -61,7 +61,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==3.0.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -140,7 +140,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements-integration.in
     #   juju
@@ -160,6 +160,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery


### PR DESCRIPTION
Bump these package versions to avoid the issues described in https://github.com/canonical/bundle-kubeflow/issues/648.

Part of https://github.com/canonical/bundle-kubeflow/issues/648