### PR TITLE
feat: enable and fix katib-db-manager unit tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -42,6 +42,19 @@ jobs:
     - name: Check flake8
       run: flake8 ./charms/*/src
 
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        charm:
+          - katib-db-manager
+    steps:
+      - uses: actions/checkout@v3
+      - run: python3 -m pip install tox
+      - run: tox -e ${{ matrix.charm }}-unit
+  
   charm-integration:
     name: Integration tests (microk8s)
     runs-on: ubuntu-20.04

--- a/charms/katib-db-manager/tests/unit/test_operator.py
+++ b/charms/katib-db-manager/tests/unit/test_operator.py
@@ -161,8 +161,22 @@ def test_update_status(
     Test update status handler.
     Check on the correct charm status when health check status is UP/DOWN.
     """
+    database = MagicMock()
+    fetch_relation_data = MagicMock()
+    fetch_relation_data.return_value = {
+        "test-db-data": {
+            "endpoints": "host:1234",
+            "username": "username",
+            "password": "password",
+        }
+    }
+    database.fetch_relation_data = fetch_relation_data
+    harness.model.get_relation = MagicMock(
+        side_effect=_get_relation_db_only_side_effect_func
+    )
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
+    harness.charm.database = database
     harness.container_pebble_ready("katib-db-manager")
 
     _get_check_status.return_value = health_check_status

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ max-line-length = 100
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit, integration, {katib-controller}-{lint,unit,integration}
-
+envlist = fmt, lint, unit, integration, {katib-controller,katib-db-manager}-{lint,unit,integration}
 [vars]
 all_path = {[vars]tst_path}
 tst_path = {toxinidir}/tests/


### PR DESCRIPTION
fixes #100
## Summary of changes
* fix the `test_update_status` unit test by adding required db relation
* enable unit tests of `katib-db-manager` in the CI and add it to the tox file