### PR TITLE
tox: Fix command for controller integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         charm:
-          - controller
+          - katib-controller
     steps:
       - uses: actions/checkout@v3
       - name: Setup operator environment


### PR DESCRIPTION
Provide the full tox environment name (i.e. `katib-controller-integration`) when running the controller integration tests through the CI to ensure the workflow works with the latest tox release (i.e. 4.9.0).

Closes #119 