### PR TITLE
feat: add TensorFlowEvent experiment to integration tests

### DIFF
--- a/tests/assets/crs/experiments/tfjob-mnist-with-summaries.yaml
+++ b/tests/assets/crs/experiments/tfjob-mnist-with-summaries.yaml
@@ -1,0 +1,73 @@
+# Source: katib/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
+# This example is slightly modified from upstream to consume less resources.
+# There's a `modified` comment where we diverge from upstream.
+# When updating this file, make sure to keep those modifications.
+---
+apiVersion: kubeflow.org/v1beta1
+kind: Experiment
+metadata:
+  name: tfjob-mnist-with-summaries
+spec:
+  parallelTrialCount: 1  # modified
+  maxTrialCount: 1  # modified
+  maxFailedTrialCount: 1  # modified
+  objective:
+    type: maximize
+    goal: 0.99
+    objectiveMetricName: accuracy
+  algorithm:
+    algorithmName: random
+  metricsCollectorSpec:
+    source:
+      fileSystemPath:
+        path: /mnist-with-summaries-logs/test
+        kind: Directory
+    collector:
+      kind: TensorFlowEvent
+  parameters:
+    - name: learning_rate
+      parameterType: double
+      feasibleSpace:
+        min: "0.01"
+        max: "0.05"
+    - name: batch_size
+      parameterType: int
+      feasibleSpace:
+        min: "32"
+        max: "64"
+  trialTemplate:
+    primaryContainerName: tensorflow
+    # In this example we can collect metrics only from the Worker pods.
+    primaryPodLabels:
+      training.kubeflow.org/replica-type: worker
+    trialParameters:
+      - name: learningRate
+        description: Learning rate for the training model
+        reference: learning_rate
+      - name: batchSize
+        description: Batch Size
+        reference: batch_size
+    trialSpec:
+      apiVersion: kubeflow.org/v1
+      kind: TFJob
+      spec:
+        tfReplicaSpecs:
+          Worker:
+            replicas: 2
+            restartPolicy: OnFailure
+            template:
+              spec:
+                containers:
+                  - name: tensorflow
+                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:latest
+                    command:
+                      - "python"
+                      - "/opt/tf-mnist-with-summaries/mnist.py"
+                      - "--epochs=1"
+                      - "--learning-rate=${trialParameters.learningRate}"
+                      - "--batch-size=${trialParameters.batchSize}"
+                      - "--log-path=/mnist-with-summaries-logs"
+                    resources:  # modified
+                      limits:  # modified
+                        memory: "2Gi"  # modified
+                        cpu: "1"  # modified


### PR DESCRIPTION
Details in #103 
add an experiment to integration tests that tests the `katib/cmd/metricscollector/v1beta1/tfevent-metricscollector` image.
deploys `training-operator` due to this type of experiment being reliant on the TFJob CRD.