### PR TITLE
fix: disable pebble health checks

### DIFF
--- a/charms/katib-db-manager/src/charm.py
+++ b/charms/katib-db-manager/src/charm.py
@@ -138,20 +138,24 @@ class KatibDBManagerOperator(CharmBase):
                     "startup": "enabled",
                     "command": self._exec_command,
                     "environment": self.service_environment,
-                    "on-check-failure": {"katib-db-manager-up": "restart"},
+                    # Disable health checks to issue #128.
+                    # FIXME: uncomment when https://github.com/canonical/katib-operators/issues/128 is closed.  # noqa E501
+                    # "on-check-failure": {"katib-db-manager-up": "restart"},
                 },
             },
-            "checks": {
-                "katib-db-manager-up": {
-                    "override": "replace",
-                    "period": "60s",
-                    "timeout": "20s",
-                    "threshold": 5,
-                    "exec": {
-                        "command": f"/bin/grpc_health_probe -addr=:{self._port}",
-                    },
-                }
-            },
+            # Disable health checks due to issue #128.
+            # FIXME: uncomment when https://github.com/canonical/katib-operators/issues/128 is closed.  # noqa E501
+            # "checks": {
+            #     "katib-db-manager-up": {
+            #         "override": "replace",
+            #         "period": "60s",
+            #         "timeout": "20s",
+            #         "threshold": 5,
+            #         "exec": {
+            #             "command": f"/bin/grpc_health_probe -addr=:{self._port}",
+            #         },
+            #     }
+            # },
         }
         return Layer(layer_config)
 
@@ -377,10 +381,12 @@ class KatibDBManagerOperator(CharmBase):
     def _on_update_status(self, event):
         """Update status actions."""
         self._on_event(event)
-        try:
-            self._refresh_status()
-        except ErrorWithStatus as err:
-            self.model.unit.status = err.status
+        # Disable health checks due to issue #128.
+        # FIXME: uncomment when https://github.com/canonical/katib-operators/issues/128 is closed.
+        # try:
+        #     self._refresh_status()
+        # except ErrorWithStatus as err:
+        #     self.model.unit.status = err.status
 
     def _on_install(self, _):
         """Installation only tasks."""

--- a/charms/katib-db-manager/src/charm.py
+++ b/charms/katib-db-manager/src/charm.py
@@ -138,7 +138,7 @@ class KatibDBManagerOperator(CharmBase):
                     "startup": "enabled",
                     "command": self._exec_command,
                     "environment": self.service_environment,
-                    # Disable health checks to issue #128.
+                    # Disable health checks due to issue #128.
                     # FIXME: uncomment when https://github.com/canonical/katib-operators/issues/128 is closed.  # noqa E501
                     # "on-check-failure": {"katib-db-manager-up": "restart"},
                 },

--- a/charms/katib-db-manager/tests/unit/test_operator.py
+++ b/charms/katib-db-manager/tests/unit/test_operator.py
@@ -139,7 +139,8 @@ def test_apply_k8s_resources_success(
     mocked_resource_handler.apply.assert_called()
     assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
 
-
+# FIXME: re-enable test when https://github.com/canonical/katib-operators/issues/128 is closed.
+@pytest.mark.skip('Skipping due to Pebble health checks being disabled. Re-enable when #128 is closed.')
 @patch("charm.KatibDBManagerOperator._get_check_status")
 @pytest.mark.parametrize(
     "health_check_status, charm_status",

--- a/charms/katib-db-manager/tests/unit/test_operator.py
+++ b/charms/katib-db-manager/tests/unit/test_operator.py
@@ -140,7 +140,7 @@ def test_apply_k8s_resources_success(
     assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
 
 # FIXME: re-enable test when https://github.com/canonical/katib-operators/issues/128 is closed.
-@pytest.mark.skip('Skipping due to Pebble health checks being disabled. Re-enable when #128 is closed.')
+@pytest.mark.skip("Skipping due to Pebble health checks being disabled. Re-enable when #128 is closed.")
 @patch("charm.KatibDBManagerOperator._get_check_status")
 @pytest.mark.parametrize(
     "health_check_status, charm_status",


### PR DESCRIPTION
As a temporary fix to #128 , disables the pebble health check is to be disabled in the code with a comment linking to this issue, to be re-enabled once the rock is integrated.