### PR TITLE
add `working-dir` to the katib-ui charm's pebble service

### DIFF
--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -115,6 +115,7 @@ class KatibUIOperator(CharmBase):
                     "override": "replace",
                     "summary": "entrypoint of the katib-ui-operator image",
                     "command": f"./katib-ui --port={self._port}",
+                    "working-dir": "/app",
                     "startup": "enabled",
                     "environment": {"KATIB_CORE_NAMESPACE": self.model.name},
                 }


### PR DESCRIPTION
This enables using a rock as a drop-in replacement for the upstream docker image

Fixes #158