### PR TITLE
add `working-dir` to the katib-ui charm's pebble service

### DIFF
--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -117,9 +117,9 @@ class KatibUIOperator(CharmBase):
                     "command": f"./katib-ui --port={self._port}",
                     # working-dir is required to interchangeably support docker images and rocks.
                     # Rocks always set their entrypoint working-dir to "/" because pebble is the
-                    # entrypoint, so we need to be explicit.  This was not needed for running 
+                    # entrypoint, so we need to be explicit.  This was not needed for running
                     # the upstream docker image because that image has a entrypoint working-dir
-                    # of "/app", which is used if working-dir is not set here. 
+                    # of "/app", which is used if working-dir is not set here.
                     "working-dir": "/app",
                     "startup": "enabled",
                     "environment": {"KATIB_CORE_NAMESPACE": self.model.name},

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -115,6 +115,11 @@ class KatibUIOperator(CharmBase):
                     "override": "replace",
                     "summary": "entrypoint of the katib-ui-operator image",
                     "command": f"./katib-ui --port={self._port}",
+                    # working-dir is required to interchangably support docker images and rocks.
+                    # Rocks always set their entrypoint working-dir to "/" because pebble is the
+                    # entrypoint, so we need to be explicit.  This was not needed for running 
+                    # the upstream docker image because that image has a entrypoint working-dir
+                    # of "/app", which is used if working-dir is not set here. 
                     "working-dir": "/app",
                     "startup": "enabled",
                     "environment": {"KATIB_CORE_NAMESPACE": self.model.name},

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -115,7 +115,7 @@ class KatibUIOperator(CharmBase):
                     "override": "replace",
                     "summary": "entrypoint of the katib-ui-operator image",
                     "command": f"./katib-ui --port={self._port}",
-                    # working-dir is required to interchangably support docker images and rocks.
+                    # working-dir is required to interchangeably support docker images and rocks.
                     # Rocks always set their entrypoint working-dir to "/" because pebble is the
                     # entrypoint, so we need to be explicit.  This was not needed for running 
                     # the upstream docker image because that image has a entrypoint working-dir

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -115,6 +115,7 @@ class KatibUIOperator(CharmBase):
                     "override": "replace",
                     "summary": "entrypoint of the katib-ui-operator image",
                     "command": f"./katib-ui --port={self._port}",
+                    "working-dir": "/app",
                     "startup": "enabled",
                     "environment": {"KATIB_CORE_NAMESPACE": self.model.name},
                 }


### PR DESCRIPTION
This enables using a rock as a drop-in replacement for the upstream docker image

Fixes #158