### PR TITLE
ci: Decrease root-reserve-mb to fit the new runner storage (#168)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'


### PR DESCRIPTION
addresses https://github.com/canonical/bundle-kubeflow/issues/813 in `track/0.16`
backports 25d7c1cab6f9c0f9a14411f1d074dac68c9573a9 