### PR TITLE
fix: Add datasource field to dashboard's target and tags

### DIFF
--- a/charms/katib-controller/src/grafana_dashboards/katib_saved_no_templating.json.tmpl
+++ b/charms/katib-controller/src/grafana_dashboards/katib_saved_no_templating.json.tmpl
@@ -23,10 +23,10 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -84,7 +84,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Current Status",
-      "type": "gauge"
+      "type": "timeseries"
     },
     {
       "aliasColors": {},


### PR DESCRIPTION
* Add `ckf` and `katib` tag to katib-controller's grafana dashboard.
* Fix `datasource` field
* Fix current experiments & trials panel by:
  * adding a `legendFormat` field
  * converting it to a time series & mapping no value to 0 in order to account
    for the fact that katib-controller doesn't output any `current` metrics when
    there is no experiment or trial running.

That's how the new dashboard looks:
![image](https://github.com/canonical/katib-operators/assets/44405072/ac3eaa87-22dd-4f30-b56b-138eb9b0fb85)

Part of canonical/bundle-kubeflow#856
Refs canonical/bundle-kubeflow#834