### PR TITLE
tests: pin deployed charms to a CKF 1.8 compatible version

### DIFF
--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -20,6 +20,10 @@ CONTROLLER_APP_NAME = CONTROLLER_METADATA["name"]
 UI_APP_NAME = UI_METADATA["name"]
 DB_APP_NAME = DB_METADATA["name"]
 
+KUBEFLOW_PROFILES = "kubeflow-profiles"
+KUBEFLOW_PROFILES_CHANNEL = "1.8/stable"
+KUBEFLOW_PROFILES_TRUST = True
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,7 +41,9 @@ async def test_deploy_katib_charms(ops_test: OpsTest):
     ui_image_path = UI_METADATA["resources"]["oci-image"]["upstream-source"]
 
     # Deploy katib-controller, katib-db-manager, and katib-ui charms
-    await ops_test.model.deploy(controller_charm, resources={"oci-image": controller_image_path})
+    await ops_test.model.deploy(
+        controller_charm, resources={"oci-image": controller_image_path},
+    )
 
     await ops_test.model.deploy(
         db_manager_charm, resources={"oci-image": db_image_path}, trust=True
@@ -63,9 +69,9 @@ async def test_deploy_katib_charms(ops_test: OpsTest):
 
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
-        entity_url="kubeflow-profiles",
-        channel="latest/edge",
-        trust=True,
+        entity_url=KUBEFLOW_PROFILES,
+        channel=KUBEFLOW_PROFILES_CHANNEL,
+        trust=KUBEFLOW_PROFILES_TRUST,
     )
 
     # Wait for everything to deploy

--- a/tests/integration/test_katib_experiments.py
+++ b/tests/integration/test_katib_experiments.py
@@ -27,7 +27,9 @@ PROFILE_RESOURCE = create_global_resource(
     kind="Profile",
     plural="profiles",
 )
-TRAINING_CHARM = "training-operator"
+TRAINING_OPERATOR = "training-operator"
+TRAINING_OPERATOR_CHANNEL = "1.7/stable"
+TRAINING_OPERATOR_TRUST = True
 
 
 @pytest.fixture(scope="module")
@@ -42,12 +44,12 @@ def lightkube_client() -> lightkube.Client:
 async def training_operator(ops_test: OpsTest):
     """Deploy training-operator charm, and wait until it's active."""
     await ops_test.model.deploy(
-        entity_url=TRAINING_CHARM,
-        channel="latest/edge",
-        trust=True,
+        entity_url=TRAINING_OPERATOR,
+        channel=TRAINING_OPERATOR_CHANNEL,
+        trust=TRAINING_OPERATOR_TRUST,
     )
     await ops_test.model.wait_for_idle(
-        apps=[TRAINING_CHARM], status="active", raise_on_blocked=False, timeout=60 * 5
+        apps=[TRAINING_OPERATOR], status="active", raise_on_blocked=False, timeout=60 * 5
     )
 
 


### PR DESCRIPTION
This commit pins all charms that get deployed from Charmhub to a compatible version to the CKF 1.8 release. 

Part of canonical/bundle-kubeflow#863