### PR TITLE
fix: Introduce `k8s-service-info` between katib-controller and katib-db-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .idea
 .tox
 .vscode
+venv/

--- a/charms/katib-controller/charmcraft.yaml
+++ b/charms/katib-controller/charmcraft.yaml
@@ -9,3 +9,5 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    # Pydantic build dependencies
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]

--- a/charms/katib-controller/lib/charms/mlops_libs/v0/k8s_service_info.py
+++ b/charms/katib-controller/lib/charms/mlops_libs/v0/k8s_service_info.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for sharing Kubernetes Services information.
+
+This library offers a Python API for providing and requesting information about
+any Kubernetes Service resource.
+The default relation name is `k8s-svc-info` and it's recommended to use that name,
+though if changed, you must ensure to pass the correct name when instantiating the
+provider and requirer classes, as well as in `metadata.yaml`.
+
+## Getting Started
+
+### Fetching the library with charmcraft
+
+Using charmcraft you can:
+```shell
+charmcraft fetch-lib charms.mlops_libs.v0.k8s_service_info
+```
+
+## Using the library as requirer
+
+### Add relation to metadata.yaml
+```yaml
+requires:
+  k8s-svc-info:
+    interface: k8s-service
+    limit: 1
+```
+
+### Instantiate the KubernetesServiceInfoRequirer class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.mlops_libs.v0.kubernetes_service_info import KubernetesServiceInfoRequirer, KubernetesServiceInfoRelationError
+
+class RequirerCharm(CharmBase):
+    def __init__(self, *args):
+        self._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            k8s_svc_info_data = self._k8s_svc_info_requirer.get_data()
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Using the library as provider
+
+### Add relation to metadata.yaml
+```yaml
+provides:
+  k8s-svc-info:
+    interface: k8s-service
+```
+
+### Instantiate the KubernetesServiceInfoProvider class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.mlops_libs.v0.kubernetes_service_info import KubernetesServiceInfoProvider, KubernetesServiceInfoRelationError
+
+class ProviderCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        ...
+        self._k8s_svc_info_provider = KubernetesServiceInfoProvider(self)
+        self.observe(self.on.some_event, self._some_event_handler)
+    def _some_event_handler(self, ...):
+        # This will update the relation data bag with the Service name and port
+        try:
+            self._k8s_svc_info_provider.send_data(name, port)
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Relation data
+
+The data shared by this library is:
+* name: the name of the Kubernetes Service
+  as it appears in the resource metadata, e.g. "metadata-grpc-service".
+* port: the port of the Kubernetes Service
+"""
+
+import logging
+from typing import List, Optional, Union
+
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import BoundEvent, EventSource, Object, ObjectEvents
+from ops.model import Relation
+from pydantic import BaseModel
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f5c3f6cc023e40468d6f9a871e8afcd0"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "k8s-service-info"
+DEFAULT_INTERFACE_NAME = "k8s-service"
+REQUIRED_ATTRIBUTES = ["name", "port"]
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesServiceInfoRelationError(Exception):
+    """Base exception class for any relation error handled by this library."""
+
+    pass
+
+
+class KubernetesServiceInfoRelationMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when the relation is missing on either end."""
+
+    def __init__(self):
+        self.message = "Missing relation with a k8s service info provider."
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoRelationDataMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when there is missing data in the relation data bag."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoUpdatedEvent(RelationEvent):
+    """Indicates the Kubernetes Service Info data was updated."""
+
+
+class KubernetesServiceInfoEvents(ObjectEvents):
+    """Events for the Kubernetes Service Info library."""
+
+    updated = EventSource(KubernetesServiceInfoUpdatedEvent)
+
+
+class KubernetesServiceInfoObject(BaseModel):
+    """Representation of a Kubernetes Service info object.
+
+    Args:
+        name: The name of the Service
+        port: The port of the Service
+    """
+
+    name: str
+    port: str
+
+
+class KubernetesServiceInfoRequirer(Object):
+    """Implement the Requirer end of the Kubernetes Service Info relation.
+
+    Observes the relation events and get data of a related application.
+
+    This library emits:
+    * KubernetesServiceInfoUpdatedEvent: when data received on the relation is updated.
+
+    Args:
+        charm (CharmBase): the provider application
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.
+                       Use this to update the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the requirer application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    on = KubernetesServiceInfoEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._requirer_wrapper = KubernetesServiceInfoRequirerWrapper(
+            self._charm, self._relation_name
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
+        )
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._on_relation_changed)
+
+    def get_data(self) -> KubernetesServiceInfoObject:
+        """Return a KubernetesServiceInfoObject."""
+        return self._requirer_wrapper.get_data()
+
+    def _on_relation_changed(self, event: BoundEvent) -> None:
+        """Handle relation-changed event for this relation."""
+        self.on.updated.emit(event.relation)
+
+    def _on_relation_broken(self, event: BoundEvent) -> None:
+        """Handle relation-broken event for this relation."""
+        self.on.updated.emit(event.relation)
+
+
+class KubernetesServiceInfoRequirerWrapper(Object):
+    """Wrapper for the relation data getting logic.
+
+    Args:
+        charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+
+    @staticmethod
+    def _validate_relation(relation: Relation) -> None:
+        """Series of checks for the relation and relation data.
+
+        Args:
+            relation (Relation): the relation object to run the checks on
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError if data is missing or incomplete
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+        """
+        # Raise if there is no related application
+        if not relation:
+            raise KubernetesServiceInfoRelationMissingError()
+
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
+
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                f"No data found in relation {relation.name} data bag."
+            )
+
+        # Check if the relation data contains the expected attributes
+        missing_attributes = [
+            attribute for attribute in REQUIRED_ATTRIBUTES if attribute not in relation_data
+        ]
+        if missing_attributes:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                f"Missing attributes: {missing_attributes} in relation {relation.name}"
+            )
+
+    def get_data(self) -> KubernetesServiceInfoObject:
+        """Return a KubernetesServiceInfoObject containing Kubernetes Service information.
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError: if data is missing entirely or some attributes
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
+        """
+        # Validate relation data
+        # Raises TooManyRelatedAppsError if related to more than one app
+        relation = self.model.get_relation(self.relation_name)
+
+        self._validate_relation(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
+
+        return KubernetesServiceInfoObject(name=relation_data["name"], port=relation_data["port"])
+
+
+class KubernetesServiceInfoProvider(Object):
+    """Implement the Provider end of the Kubernetes Service Info relation.
+
+    Observes relation events to send data to related applications.
+
+    Args:
+        charm (CharmBase): the provider application
+        name (str): the name of the Kubernetes Service the provider knows about
+        port (str): the port number of the Kubernetes Service the provider knows about
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
+                       the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        name: str,
+        port: str,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self._provider_wrapper = KubernetesServiceInfoProviderWrapper(
+            self.charm, self.relation_name
+        )
+        self._svc_name = name
+        self._svc_port = port
+
+        self.framework.observe(self.charm.on.leader_elected, self._send_data)
+
+        self.framework.observe(self.charm.on[self.relation_name].relation_created, self._send_data)
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._send_data)
+
+    def _send_data(self, _) -> None:
+        """Serve as an event handler for sending the Kubernetes Service information."""
+        self._provider_wrapper.send_data(self._svc_name, self._svc_port)
+
+
+class KubernetesServiceInfoProviderWrapper(Object):
+    """Wrapper for the relation data sending logic.
+
+    Args:
+        charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def send_data(
+        self,
+        name: str,
+        port: str,
+    ) -> None:
+        """Update the relation data bag with data from a Kubernetes Service.
+
+        This method will complete successfully even if there are no related applications.
+
+        Args:
+            name (str): the name of the Kubernetes Service the provider knows about
+            port (str): the port number of the Kubernetes Service the provider knows about
+        """
+        # Validate unit is leader to send data; otherwise return
+        if not self.charm.model.unit.is_leader():
+            logger.info(
+                "KubernetesServiceInfoProvider handled send_data event when it is not the leader."
+                "Skipping event - no data sent."
+            )
+        # Update the relation data bag with a Kubernetes Service information
+        relations = self.charm.model.relations[self.relation_name]
+
+        # Update relation data
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "name": name,
+                    "port": port,
+                }
+            )

--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -21,3 +21,7 @@ provides:
     interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard
+requires:
+  k8s-service-info:
+    interface: k8s-service
+    limit: 1

--- a/charms/katib-controller/requirements-unit.txt
+++ b/charms/katib-controller/requirements-unit.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements-unit.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==4.3.0
     # via httpx
 attrs==23.2.0
@@ -69,6 +71,10 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.4.0
     # via pytest
+pydantic==2.6.4
+    # via -r requirements.in
+pydantic-core==2.16.3
+    # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
 pytest==8.0.1
@@ -106,8 +112,11 @@ tomli==2.0.1
     # via pytest
 typing-extensions==4.9.0
     # via
+    #   annotated-types
     #   anyio
     #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.2.1
     # via requests
 websocket-client==1.7.0

--- a/charms/katib-controller/requirements.in
+++ b/charms/katib-controller/requirements.in
@@ -7,9 +7,6 @@ pyyaml==6.0.1
 # from prometheus_k8s.v0.prometheus_scrape.py
 cosl
 # This is a requirement from the k8s_service_info library
-# # pydantic>=2.7 requires rustc v1.76 or newer,
-# which is not available in the base OS this charm has at the moment (Ubuntu 20.04).
-# To avoid build-time errors, pydantic has to be pinned to a version that can be built
-# with the rustc version that the OS can provide.
+# Pin due to https://github.com/canonical/bundle-kubeflow/issues/926
 # Remove this pin when the base OS can install rustc v1.76 or newer.
 pydantic>=2.6,<2.7

--- a/charms/katib-controller/requirements.in
+++ b/charms/katib-controller/requirements.in
@@ -6,3 +6,10 @@ ops
 pyyaml==6.0.1
 # from prometheus_k8s.v0.prometheus_scrape.py
 cosl
+# This is a requirement from the k8s_service_info library
+# # pydantic>=2.7 requires rustc v1.76 or newer,
+# which is not available in the base OS this charm has at the moment (Ubuntu 20.04).
+# To avoid build-time errors, pydantic has to be pinned to a version that can be built
+# with the rustc version that the OS can provide.
+# Remove this pin when the base OS can install rustc v1.76 or newer.
+pydantic>=2.6,<2.7

--- a/charms/katib-controller/requirements.txt
+++ b/charms/katib-controller/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==4.3.0
     # via httpx
 attrs==23.2.0
@@ -58,6 +60,10 @@ ordered-set==4.1.0
     # via deepdiff
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+pydantic==2.6.4
+    # via -r requirements.in
+pydantic-core==2.16.3
+    # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
 pyyaml==6.0.1
@@ -83,8 +89,11 @@ tenacity==8.2.3
     # via charmed-kubeflow-chisme
 typing-extensions==4.9.0
     # via
+    #   annotated-types
     #   anyio
     #   cosl
+    #   pydantic
+    #   pydantic-core
 urllib3==2.2.1
     # via requests
 websocket-client==1.6.1

--- a/charms/katib-controller/src/charm.py
+++ b/charms/katib-controller/src/charm.py
@@ -158,7 +158,7 @@ class KatibControllerOperator(CharmBase):
         with tempfile.NamedTemporaryFile(delete=False) as ca_file:
             ca_file.write(self._stored.ca.encode("utf-8"))
 
-        self.k8s_service_info = self.charm_reconciler.add(
+        self.k8s_service_info_requirer = self.charm_reconciler.add(
             component=K8sServiceInfoRequirerComponent(charm=self),
             depends_on=[self.leadership_gate],
         )
@@ -191,11 +191,15 @@ class KatibControllerOperator(CharmBase):
                 inputs_getter=lambda: KatibControllerInputs(
                     NAMESPACE=self.model.name,
                     KATIB_DB_MANAGER_SERVICE_PORT=(
-                        self.k8s_service_info.component.get_service_info().port
+                        self.k8s_service_info_requirer.component.get_service_info().port
                     ),
                 ),
             ),
-            depends_on=[self.leadership_gate, self.kubernetes_resources, self.k8s_service_info],
+            depends_on=[
+                self.leadership_gate,
+                self.kubernetes_resources,
+                self.k8s_service_info_requirer,
+            ],
         )
 
         self.charm_reconciler.install_default_event_handlers()

--- a/charms/katib-controller/src/charm.py
+++ b/charms/katib-controller/src/charm.py
@@ -32,6 +32,7 @@ from ops.framework import StoredState
 from ops.main import main
 
 from certs import gen_certs
+from components.k8s_service_info_requirer_component import K8sServiceInfoRequirerComponent
 from components.pebble_component import KatibControllerInputs, KatibControllerPebbleService
 
 DEFAULT_IMAGES_FILE = "src/default-custom-images.json"
@@ -157,6 +158,11 @@ class KatibControllerOperator(CharmBase):
         with tempfile.NamedTemporaryFile(delete=False) as ca_file:
             ca_file.write(self._stored.ca.encode("utf-8"))
 
+        self.k8s_service_info = self.charm_reconciler.add(
+            component=K8sServiceInfoRequirerComponent(charm=self),
+            depends_on=[self.leadership_gate],
+        )
+
         self.katib_controller_container = self.charm_reconciler.add(
             component=KatibControllerPebbleService(
                 charm=self,
@@ -182,9 +188,14 @@ class KatibControllerOperator(CharmBase):
                         context_function=self._katib_config_context,
                     ),
                 ],
-                inputs_getter=lambda: KatibControllerInputs(NAMESPACE=self.model.name),
+                inputs_getter=lambda: KatibControllerInputs(
+                    NAMESPACE=self.model.name,
+                    KATIB_DB_MANAGER_SERVICE_PORT=(
+                        self.k8s_service_info.component.get_service_info().port
+                    ),
+                ),
             ),
-            depends_on=[self.leadership_gate, self.kubernetes_resources],
+            depends_on=[self.leadership_gate, self.kubernetes_resources, self.k8s_service_info],
         )
 
         self.charm_reconciler.install_default_event_handlers()

--- a/charms/katib-controller/src/components/k8s_service_info_requirer_component.py
+++ b/charms/katib-controller/src/components/k8s_service_info_requirer_component.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright 2024 Ubuntu
+# See LICENSE file for licensing details.
+
+import logging
+from typing import Optional
+
+from charmed_kubeflow_chisme.components.component import Component
+from charms.mlops_libs.v0.k8s_service_info import (
+    KubernetesServiceInfoObject,
+    KubernetesServiceInfoRelationDataMissingError,
+    KubernetesServiceInfoRelationMissingError,
+    KubernetesServiceInfoRequirer,
+)
+from ops import ActiveStatus, BlockedStatus, CharmBase, StatusBase, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+
+class K8sServiceInfoRequirerComponent(Component):
+    """A Component that wraps the requirer side of the k8s_service_info charm library.
+
+    Args:
+        charm(CharmBase): the requirer charm
+        relation_name(str, Optional): name of the relation that uses the k8s-service interface
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: Optional[str] = "k8s-service-info",
+    ):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+        self._k8s_service_info_requirer = KubernetesServiceInfoRequirer(
+            charm=self.charm,
+            relation_name=self.relation_name,
+        )
+
+        self._events_to_observe = [
+            self._k8s_service_info_requirer.on.updated,
+            self.charm.on[relation_name].relation_broken,
+        ]
+
+    def get_service_info(self) -> KubernetesServiceInfoObject:
+        """Wrap the get_data method and return a KubernetesServiceInfoObject."""
+        return self._k8s_service_info_requirer.get_data()
+
+    def get_status(self) -> StatusBase:
+        """Return this component's status based on the presence of the relation and its data."""
+        try:
+            self.get_service_info()
+        except KubernetesServiceInfoRelationMissingError as rel_error:
+            return BlockedStatus(f"{rel_error.message} Please add the missing relation.")
+        except KubernetesServiceInfoRelationDataMissingError as data_error:
+            logger.error(f"Empty or missing data. Got: {data_error.message}")
+            return WaitingStatus(
+                f"Empty or missing data in {self.relation_name} relation."
+                " This may be transient, but if it persists it is likely an error."
+            )
+        return ActiveStatus()

--- a/charms/katib-controller/src/components/pebble_component.py
+++ b/charms/katib-controller/src/components/pebble_component.py
@@ -14,6 +14,7 @@ class KatibControllerInputs:
     """Defines the required inputs for KatibControllerPebbleService."""
 
     NAMESPACE: str
+    KATIB_DB_MANAGER_SERVICE_PORT: str
 
 
 class KatibControllerPebbleService(PebbleServiceComponent):
@@ -41,6 +42,9 @@ class KatibControllerPebbleService(PebbleServiceComponent):
                         "startup": "enabled",
                         "environment": {
                             "KATIB_CORE_NAMESPACE": str(inputs.NAMESPACE).lower(),
+                            "KATIB_DB_MANAGER_SERVICE_PORT": str(
+                                inputs.KATIB_DB_MANAGER_SERVICE_PORT
+                            ),
                         },
                     }
                 },

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -11,7 +11,6 @@ CHARM_NAME = METADATA["name"]
 KATIB_CONFIG = "katib-config"
 KATIB_DB_MANAGER = "katib-db-manager"
 KATIB_DB_MANAGER_CHANNEL = "latest/edge"
-KATIB_DB_MANAGER_TRUST = True
 TRIAL_TEMPLATE = "trial-template"
 EXPECTED_KATIB_CONFIG = {
     "katib-config.yaml": "---\napiVersion: config.kubeflow.org/v1beta1\nkind: KatibConfig\ninit:\n  controller:\n    webhookPort: 443\n    trialResources:\n      - Job.v1.batch\n      - TFJob.v1.kubeflow.org\n      - PyTorchJob.v1.kubeflow.org\n      - MPIJob.v1.kubeflow.org\n      - XGBoostJob.v1.kubeflow.org\n      - MXJob.v1.kubeflow.org\nruntime:\n  metricsCollectors:\n    - kind: StdOut\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: File\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: TensorFlowEvent\n      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 1Gi\n  suggestions:\n    - algorithmName: random\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: tpe\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: grid\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: hyperband\n      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.0\n    - algorithmName: bayesianoptimization\n      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.0\n    - algorithmName: cmaes\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: sobol\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: multivariate-tpe\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: enas\n      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 400Mi\n    - algorithmName: darts\n      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.0\n    - algorithmName: pbt\n      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.0\n      persistentVolumeClaimSpec:\n        accessModes:\n          - ReadWriteMany\n        resources:\n          requests:\n            storage: 5Gi\n  earlyStoppings:\n    - algorithmName: medianstop\n      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.0",  # noqa: E501
@@ -56,7 +55,7 @@ class TestCharm:
             db_manager_charm, resources={"oci-image": db__manager_image_path}, trust=True
         )
         # await ops_test.model.deploy(
-        #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
+        #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=True
         # )
 
         charm_under_test = await ops_test.build_charm(".")

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -12,12 +12,6 @@ KATIB_CONFIG = "katib-config"
 KATIB_DB_MANAGER = "katib-db-manager"
 KATIB_DB_MANAGER_CHANNEL = "latest/edge"
 KATIB_DB_MANAGER_TRUST = True
-KATIB_DB_CHARM = "mysql-k8s"
-KATIB_DB = "katib-db"
-KATIB_DB_CHANNEL = "8.0/stable"
-KATIB_DB_TRUST = True
-KATIB_DB = "katib-db"
-KATIB_DB_CONFIG = {"profile": "testing"}
 TRIAL_TEMPLATE = "trial-template"
 EXPECTED_KATIB_CONFIG = {
     "katib-config.yaml": "---\napiVersion: config.kubeflow.org/v1beta1\nkind: KatibConfig\ninit:\n  controller:\n    webhookPort: 443\n    trialResources:\n      - Job.v1.batch\n      - TFJob.v1.kubeflow.org\n      - PyTorchJob.v1.kubeflow.org\n      - MPIJob.v1.kubeflow.org\n      - XGBoostJob.v1.kubeflow.org\n      - MXJob.v1.kubeflow.org\nruntime:\n  metricsCollectors:\n    - kind: StdOut\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: File\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: TensorFlowEvent\n      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 1Gi\n  suggestions:\n    - algorithmName: random\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: tpe\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: grid\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: hyperband\n      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.0\n    - algorithmName: bayesianoptimization\n      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.0\n    - algorithmName: cmaes\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: sobol\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: multivariate-tpe\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: enas\n      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 400Mi\n    - algorithmName: darts\n      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.0\n    - algorithmName: pbt\n      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.0\n      persistentVolumeClaimSpec:\n        accessModes:\n          - ReadWriteMany\n        resources:\n          requests:\n            storage: 5Gi\n  earlyStoppings:\n    - algorithmName: medianstop\n      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.0",  # noqa: E501
@@ -64,14 +58,6 @@ class TestCharm:
         # await ops_test.model.deploy(
         #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
         # )
-        await ops_test.model.deploy(
-            KATIB_DB_CHARM,
-            application_name=KATIB_DB,
-            channel=KATIB_DB_CHANNEL,
-            trust=KATIB_DB_TRUST,
-            config=KATIB_DB_CONFIG,
-        )
-        await ops_test.model.integrate(f"{KATIB_DB}:database", f"{KATIB_DB_MANAGER}:relational-db")
 
         charm_under_test = await ops_test.build_charm(".")
         image_path = METADATA["resources"]["oci-image"]["upstream-source"]

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -45,7 +45,8 @@ class TestCharm:
         Assert on the unit status.
         """
         # Building the charm as a temporary workaround since this PR introduces a new relation.
-        # Once this PR is merged, a follow-up will remove the following code and uncomment the line below.
+        # Once this PR is merged, a follow-up PR will remove the following code
+        # and uncomment the line below.
         db_manager_path = Path("../katib-db-manager")
         db_manager_metadata = yaml.safe_load(Path(f"{db_manager_path}/metadata.yaml").read_text())
         db__manager_image_path = db_manager_metadata["resources"]["oci-image"]["upstream-source"]

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -49,10 +49,10 @@ class TestCharm:
         # and uncomment the line below.
         db_manager_path = Path("../katib-db-manager")
         db_manager_metadata = yaml.safe_load(Path(f"{db_manager_path}/metadata.yaml").read_text())
-        db__manager_image_path = db_manager_metadata["resources"]["oci-image"]["upstream-source"]
+        db_manager_image_path = db_manager_metadata["resources"]["oci-image"]["upstream-source"]
         db_manager_charm = await ops_test.build_charm(db_manager_path)
         await ops_test.model.deploy(
-            db_manager_charm, resources={"oci-image": db__manager_image_path}, trust=True
+            db_manager_charm, resources={"oci-image": db_manager_image_path}, trust=True
         )
         # await ops_test.model.deploy(
         #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=True

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -44,9 +44,18 @@ class TestCharm:
 
         Assert on the unit status.
         """
+        # Building the charm as a temporary workaround since this PR introduces a new relation.
+        # Once this PR is merged, a follow-up will remove the following code and uncomment the line below.
+        db_manager_path = Path("../katib-db-manager")
+        db_manager_metadata = yaml.safe_load(Path(f"{db_manager_path}/metadata.yaml").read_text())
+        db__manager_image_path = db_manager_metadata["resources"]["oci-image"]["upstream-source"]
+        db_manager_charm = await ops_test.build_charm(db_manager_path)
         await ops_test.model.deploy(
-            KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
+            db_manager_charm, resources={"oci-image": db__manager_image_path}, trust=True
         )
+        # await ops_test.model.deploy(
+        #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
+        # )
 
         charm_under_test = await ops_test.build_charm(".")
         image_path = METADATA["resources"]["oci-image"]["upstream-source"]

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -12,6 +12,12 @@ KATIB_CONFIG = "katib-config"
 KATIB_DB_MANAGER = "katib-db-manager"
 KATIB_DB_MANAGER_CHANNEL = "latest/edge"
 KATIB_DB_MANAGER_TRUST = True
+KATIB_DB_CHARM = "mysql-k8s"
+KATIB_DB = "katib-db"
+KATIB_DB_CHANNEL = "8.0/stable"
+KATIB_DB_TRUST = True
+KATIB_DB = "katib-db"
+KATIB_DB_CONFIG = {"profile": "testing"}
 TRIAL_TEMPLATE = "trial-template"
 EXPECTED_KATIB_CONFIG = {
     "katib-config.yaml": "---\napiVersion: config.kubeflow.org/v1beta1\nkind: KatibConfig\ninit:\n  controller:\n    webhookPort: 443\n    trialResources:\n      - Job.v1.batch\n      - TFJob.v1.kubeflow.org\n      - PyTorchJob.v1.kubeflow.org\n      - MPIJob.v1.kubeflow.org\n      - XGBoostJob.v1.kubeflow.org\n      - MXJob.v1.kubeflow.org\nruntime:\n  metricsCollectors:\n    - kind: StdOut\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: File\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: TensorFlowEvent\n      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 1Gi\n  suggestions:\n    - algorithmName: random\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: tpe\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: grid\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: hyperband\n      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.0\n    - algorithmName: bayesianoptimization\n      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.0\n    - algorithmName: cmaes\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: sobol\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: multivariate-tpe\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: enas\n      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 400Mi\n    - algorithmName: darts\n      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.0\n    - algorithmName: pbt\n      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.0\n      persistentVolumeClaimSpec:\n        accessModes:\n          - ReadWriteMany\n        resources:\n          requests:\n            storage: 5Gi\n  earlyStoppings:\n    - algorithmName: medianstop\n      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.0",  # noqa: E501
@@ -44,6 +50,7 @@ class TestCharm:
 
         Assert on the unit status.
         """
+        # Deploy dependencies katib-db-manager and katib-db which is a dependency of the latter.
         # Building the charm as a temporary workaround since this PR introduces a new relation.
         # Once this PR is merged, a follow-up PR will remove the following code
         # and uncomment the line below.
@@ -57,6 +64,14 @@ class TestCharm:
         # await ops_test.model.deploy(
         #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
         # )
+        await ops_test.model.deploy(
+            KATIB_DB_CHARM,
+            application_name=KATIB_DB,
+            channel=KATIB_DB_CHANNEL,
+            trust=KATIB_DB_TRUST,
+            config=KATIB_DB_CONFIG,
+        )
+        await ops_test.model.integrate(f"{KATIB_DB}:database", f"{KATIB_DB_MANAGER}:relational-db")
 
         charm_under_test = await ops_test.build_charm(".")
         image_path = METADATA["resources"]["oci-image"]["upstream-source"]
@@ -68,11 +83,9 @@ class TestCharm:
             application_name=CHARM_NAME,
             trust=True,
         )
-        await ops_test.model.add_relation(CHARM_NAME, KATIB_DB_MANAGER)
+        await ops_test.model.integrate(CHARM_NAME, KATIB_DB_MANAGER)
 
-        await ops_test.model.wait_for_idle(
-            apps=[CHARM_NAME], status="active", raise_on_blocked=True, timeout=300
-        )
+        await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=300)
 
     async def test_configmap_created(self, lightkube_client: lightkube.Client, ops_test: OpsTest):
         """Test configmaps contents with default coonfig."""

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -9,6 +9,9 @@ from pytest_operator.plugin import OpsTest
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
 KATIB_CONFIG = "katib-config"
+KATIB_DB_MANAGER = "katib-db-manager"
+KATIB_DB_MANAGER_CHANNEL = "latest/edge"
+KATIB_DB_MANAGER_TRUST = True
 TRIAL_TEMPLATE = "trial-template"
 EXPECTED_KATIB_CONFIG = {
     "katib-config.yaml": "---\napiVersion: config.kubeflow.org/v1beta1\nkind: KatibConfig\ninit:\n  controller:\n    webhookPort: 443\n    trialResources:\n      - Job.v1.batch\n      - TFJob.v1.kubeflow.org\n      - PyTorchJob.v1.kubeflow.org\n      - MPIJob.v1.kubeflow.org\n      - XGBoostJob.v1.kubeflow.org\n      - MXJob.v1.kubeflow.org\nruntime:\n  metricsCollectors:\n    - kind: StdOut\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: File\n      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.0\n    - kind: TensorFlowEvent\n      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 1Gi\n  suggestions:\n    - algorithmName: random\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: tpe\n      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.0\n    - algorithmName: grid\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: hyperband\n      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.0\n    - algorithmName: bayesianoptimization\n      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.0\n    - algorithmName: cmaes\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: sobol\n      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.0\n    - algorithmName: multivariate-tpe\n      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.0\n    - algorithmName: enas\n      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.0\n      resources:\n        limits:\n          memory: 400Mi\n    - algorithmName: darts\n      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.0\n    - algorithmName: pbt\n      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.0\n      persistentVolumeClaimSpec:\n        accessModes:\n          - ReadWriteMany\n        resources:\n          requests:\n            storage: 5Gi\n  earlyStoppings:\n    - algorithmName: medianstop\n      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.0",  # noqa: E501
@@ -41,6 +44,10 @@ class TestCharm:
 
         Assert on the unit status.
         """
+        await ops_test.model.deploy(
+            KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=KATIB_DB_MANAGER_TRUST
+        )
+
         charm_under_test = await ops_test.build_charm(".")
         image_path = METADATA["resources"]["oci-image"]["upstream-source"]
         resources = {"oci-image": image_path}
@@ -51,6 +58,7 @@ class TestCharm:
             application_name=CHARM_NAME,
             trust=True,
         )
+        await ops_test.model.add_relation(CHARM_NAME, KATIB_DB_MANAGER)
 
         await ops_test.model.wait_for_idle(
             apps=[CHARM_NAME], status="active", raise_on_blocked=True, timeout=300

--- a/charms/katib-controller/tests/unit/test_charm.py
+++ b/charms/katib-controller/tests/unit/test_charm.py
@@ -111,9 +111,9 @@ def test_no_k8s_service_info_relation(
 
     assert (
         "Missing relation with a k8s service info provider. Please add the missing relation."
-        in harness.charm.k8s_service_info.status.message
+        in harness.charm.k8s_service_info_requirer.status.message
     )
-    assert isinstance(harness.charm.k8s_service_info.status, BlockedStatus)
+    assert isinstance(harness.charm.k8s_service_info_requirer.status, BlockedStatus)
     assert not isinstance(harness.charm.model.unit.status, ActiveStatus)
 
 
@@ -131,7 +131,7 @@ def test_many_k8s_service_info_relations(
     harness.begin_with_initial_hooks()
 
     with pytest.raises(TooManyRelatedAppsError) as error:
-        harness.charm.k8s_service_info.get_status()
+        harness.charm.k8s_service_info_requirer.get_status()
 
     assert "Too many remote applications on k8s-service-info (2 > 1)" in error.value.args
     assert not isinstance(harness.charm.model.unit.status, ActiveStatus)

--- a/charms/katib-controller/tests/unit/test_charm.py
+++ b/charms/katib-controller/tests/unit/test_charm.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, BlockedStatus, TooManyRelatedAppsError
 from ops.testing import Harness
 
 from charm import KatibControllerOperator
@@ -14,6 +14,8 @@ from charm import KatibControllerOperator
 IMAGES_CONTEXT = json.loads(Path("src/default-custom-images.json").read_text())
 
 TEST_NAMESPACE = "test-namespace"
+K8S_SERVICE_INFO_RELATION_NAME = "k8s-service-info"
+K8S_SERVICE_INFO_RELATION_DATA = {"name": "service-name", "port": "1234"}
 EXPECTED_PEBBLE_LAYER = {
     "services": {
         "katib-controller": {
@@ -23,6 +25,7 @@ EXPECTED_PEBBLE_LAYER = {
             "startup": "enabled",
             "environment": {
                 "KATIB_CORE_NAMESPACE": f"{TEST_NAMESPACE}",
+                "KATIB_DB_MANAGER_SERVICE_PORT": f"{K8S_SERVICE_INFO_RELATION_DATA['port']}",
             },
         }
     }
@@ -99,13 +102,47 @@ def test_get_certs(harness, mocked_lightkube_client, mocked_kubernetes_service_p
         assert hasattr(harness.charm._stored, attr)
 
 
+def test_no_k8s_service_info_relation(
+    harness, mocked_lightkube_client, mocked_kubernetes_service_patch
+):
+    """Test the k8s_service_info component and charm are not active when no relation is present."""
+    harness.set_leader(True)
+    harness.begin_with_initial_hooks()
+
+    assert (
+        "Missing relation with a k8s service info provider. Please add the missing relation."
+        in harness.charm.k8s_service_info.status.message
+    )
+    assert isinstance(harness.charm.k8s_service_info.status, BlockedStatus)
+    assert not isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+
+def test_many_k8s_service_info_relations(
+    harness, mocked_lightkube_client, mocked_kubernetes_service_patch
+):
+    """Test the k8s_service_info component and charm are not active when >1 k8s_service_info relations are present."""
+    harness.set_leader(True)
+
+    setup_k8s_service_info_relation(harness, "remote-app-one")
+    setup_k8s_service_info_relation(harness, "remote-app-two")
+
+    harness.begin_with_initial_hooks()
+
+    with pytest.raises(TooManyRelatedAppsError) as error:
+        harness.charm.k8s_service_info.get_status()
+
+    assert "Too many remote applications on k8s-service-info (2 > 1)" in error.value.args
+    assert not isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+
 def test_pebble_services_running(
     harness, mocked_lightkube_client, mocked_kubernetes_service_patch
 ):
     """Test that if the Kubernetes Component is Active, the pebble services successfully start."""
     # Arrange
     harness.set_model_name(TEST_NAMESPACE)
-    harness.begin()
+    setup_k8s_service_info_relation(harness, "remote-test-app")
+    harness.begin_with_initial_hooks()
     harness.set_can_connect("katib-controller", True)
 
     # Mock:
@@ -123,3 +160,12 @@ def test_pebble_services_running(
     assert service.is_running()
     actual_layer = harness.get_container_pebble_plan("katib-controller").to_dict()
     assert EXPECTED_PEBBLE_LAYER == actual_layer
+
+
+def setup_k8s_service_info_relation(harness: Harness, name: str):
+    rel_id = harness.add_relation(
+        relation_name=K8S_SERVICE_INFO_RELATION_NAME,
+        remote_app=name,
+        app_data=K8S_SERVICE_INFO_RELATION_DATA,
+    )
+    return rel_id

--- a/charms/katib-controller/tests/unit/test_charm.py
+++ b/charms/katib-controller/tests/unit/test_charm.py
@@ -120,7 +120,9 @@ def test_no_k8s_service_info_relation(
 def test_many_k8s_service_info_relations(
     harness, mocked_lightkube_client, mocked_kubernetes_service_patch
 ):
-    """Test the k8s_service_info component and charm are not active when >1 k8s_service_info relations are present."""
+    """Test the k8s_service_info component and charm are not active when >1
+    k8s_service_info relations are present.
+    """
     harness.set_leader(True)
 
     setup_k8s_service_info_relation(harness, "remote-app-one")

--- a/charms/katib-db-manager/charmcraft.yaml
+++ b/charms/katib-db-manager/charmcraft.yaml
@@ -9,3 +9,5 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    # Pydantic build dependencies
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]

--- a/charms/katib-db-manager/charmcraft.yaml
+++ b/charms/katib-db-manager/charmcraft.yaml
@@ -8,5 +8,4 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    # Remove when pypa/setuptools_scm#713 gets fixed
-    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]
+    charm-python-packages: [setuptools, pip]

--- a/charms/katib-db-manager/lib/charms/mlops_libs/v0/k8s_service_info.py
+++ b/charms/katib-db-manager/lib/charms/mlops_libs/v0/k8s_service_info.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for sharing Kubernetes Services information.
+
+This library offers a Python API for providing and requesting information about
+any Kubernetes Service resource.
+The default relation name is `k8s-svc-info` and it's recommended to use that name,
+though if changed, you must ensure to pass the correct name when instantiating the
+provider and requirer classes, as well as in `metadata.yaml`.
+
+## Getting Started
+
+### Fetching the library with charmcraft
+
+Using charmcraft you can:
+```shell
+charmcraft fetch-lib charms.mlops_libs.v0.k8s_service_info
+```
+
+## Using the library as requirer
+
+### Add relation to metadata.yaml
+```yaml
+requires:
+  k8s-svc-info:
+    interface: k8s-service
+    limit: 1
+```
+
+### Instantiate the KubernetesServiceInfoRequirer class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.mlops_libs.v0.kubernetes_service_info import KubernetesServiceInfoRequirer, KubernetesServiceInfoRelationError
+
+class RequirerCharm(CharmBase):
+    def __init__(self, *args):
+        self._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            k8s_svc_info_data = self._k8s_svc_info_requirer.get_data()
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Using the library as provider
+
+### Add relation to metadata.yaml
+```yaml
+provides:
+  k8s-svc-info:
+    interface: k8s-service
+```
+
+### Instantiate the KubernetesServiceInfoProvider class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.mlops_libs.v0.kubernetes_service_info import KubernetesServiceInfoProvider, KubernetesServiceInfoRelationError
+
+class ProviderCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        ...
+        self._k8s_svc_info_provider = KubernetesServiceInfoProvider(self)
+        self.observe(self.on.some_event, self._some_event_handler)
+    def _some_event_handler(self, ...):
+        # This will update the relation data bag with the Service name and port
+        try:
+            self._k8s_svc_info_provider.send_data(name, port)
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Relation data
+
+The data shared by this library is:
+* name: the name of the Kubernetes Service
+  as it appears in the resource metadata, e.g. "metadata-grpc-service".
+* port: the port of the Kubernetes Service
+"""
+
+import logging
+from typing import List, Optional, Union
+
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import BoundEvent, EventSource, Object, ObjectEvents
+from ops.model import Relation
+from pydantic import BaseModel
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f5c3f6cc023e40468d6f9a871e8afcd0"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "k8s-service-info"
+DEFAULT_INTERFACE_NAME = "k8s-service"
+REQUIRED_ATTRIBUTES = ["name", "port"]
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesServiceInfoRelationError(Exception):
+    """Base exception class for any relation error handled by this library."""
+
+    pass
+
+
+class KubernetesServiceInfoRelationMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when the relation is missing on either end."""
+
+    def __init__(self):
+        self.message = "Missing relation with a k8s service info provider."
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoRelationDataMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when there is missing data in the relation data bag."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoUpdatedEvent(RelationEvent):
+    """Indicates the Kubernetes Service Info data was updated."""
+
+
+class KubernetesServiceInfoEvents(ObjectEvents):
+    """Events for the Kubernetes Service Info library."""
+
+    updated = EventSource(KubernetesServiceInfoUpdatedEvent)
+
+
+class KubernetesServiceInfoObject(BaseModel):
+    """Representation of a Kubernetes Service info object.
+
+    Args:
+        name: The name of the Service
+        port: The port of the Service
+    """
+
+    name: str
+    port: str
+
+
+class KubernetesServiceInfoRequirer(Object):
+    """Implement the Requirer end of the Kubernetes Service Info relation.
+
+    Observes the relation events and get data of a related application.
+
+    This library emits:
+    * KubernetesServiceInfoUpdatedEvent: when data received on the relation is updated.
+
+    Args:
+        charm (CharmBase): the provider application
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.
+                       Use this to update the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the requirer application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    on = KubernetesServiceInfoEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._requirer_wrapper = KubernetesServiceInfoRequirerWrapper(
+            self._charm, self._relation_name
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
+        )
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._on_relation_changed)
+
+    def get_data(self) -> KubernetesServiceInfoObject:
+        """Return a KubernetesServiceInfoObject."""
+        return self._requirer_wrapper.get_data()
+
+    def _on_relation_changed(self, event: BoundEvent) -> None:
+        """Handle relation-changed event for this relation."""
+        self.on.updated.emit(event.relation)
+
+    def _on_relation_broken(self, event: BoundEvent) -> None:
+        """Handle relation-broken event for this relation."""
+        self.on.updated.emit(event.relation)
+
+
+class KubernetesServiceInfoRequirerWrapper(Object):
+    """Wrapper for the relation data getting logic.
+
+    Args:
+        charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+
+    @staticmethod
+    def _validate_relation(relation: Relation) -> None:
+        """Series of checks for the relation and relation data.
+
+        Args:
+            relation (Relation): the relation object to run the checks on
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError if data is missing or incomplete
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+        """
+        # Raise if there is no related application
+        if not relation:
+            raise KubernetesServiceInfoRelationMissingError()
+
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
+
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                f"No data found in relation {relation.name} data bag."
+            )
+
+        # Check if the relation data contains the expected attributes
+        missing_attributes = [
+            attribute for attribute in REQUIRED_ATTRIBUTES if attribute not in relation_data
+        ]
+        if missing_attributes:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                f"Missing attributes: {missing_attributes} in relation {relation.name}"
+            )
+
+    def get_data(self) -> KubernetesServiceInfoObject:
+        """Return a KubernetesServiceInfoObject containing Kubernetes Service information.
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError: if data is missing entirely or some attributes
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
+        """
+        # Validate relation data
+        # Raises TooManyRelatedAppsError if related to more than one app
+        relation = self.model.get_relation(self.relation_name)
+
+        self._validate_relation(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
+
+        return KubernetesServiceInfoObject(name=relation_data["name"], port=relation_data["port"])
+
+
+class KubernetesServiceInfoProvider(Object):
+    """Implement the Provider end of the Kubernetes Service Info relation.
+
+    Observes relation events to send data to related applications.
+
+    Args:
+        charm (CharmBase): the provider application
+        name (str): the name of the Kubernetes Service the provider knows about
+        port (str): the port number of the Kubernetes Service the provider knows about
+        refresh_event: (list, optional): list of BoundEvents that this manager should handle.  Use this to update
+                       the data sent on this relation on demand.
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        name: str,
+        port: str,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self._provider_wrapper = KubernetesServiceInfoProviderWrapper(
+            self.charm, self.relation_name
+        )
+        self._svc_name = name
+        self._svc_port = port
+
+        self.framework.observe(self.charm.on.leader_elected, self._send_data)
+
+        self.framework.observe(self.charm.on[self.relation_name].relation_created, self._send_data)
+
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+            for evt in refresh_event:
+                self.framework.observe(evt, self._send_data)
+
+    def _send_data(self, _) -> None:
+        """Serve as an event handler for sending the Kubernetes Service information."""
+        self._provider_wrapper.send_data(self._svc_name, self._svc_port)
+
+
+class KubernetesServiceInfoProviderWrapper(Object):
+    """Wrapper for the relation data sending logic.
+
+    Args:
+        charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, charm: CharmBase, relation_name: Optional[str] = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def send_data(
+        self,
+        name: str,
+        port: str,
+    ) -> None:
+        """Update the relation data bag with data from a Kubernetes Service.
+
+        This method will complete successfully even if there are no related applications.
+
+        Args:
+            name (str): the name of the Kubernetes Service the provider knows about
+            port (str): the port number of the Kubernetes Service the provider knows about
+        """
+        # Validate unit is leader to send data; otherwise return
+        if not self.charm.model.unit.is_leader():
+            logger.info(
+                "KubernetesServiceInfoProvider handled send_data event when it is not the leader."
+                "Skipping event - no data sent."
+            )
+        # Update the relation data bag with a Kubernetes Service information
+        relations = self.charm.model.relations[self.relation_name]
+
+        # Update relation data
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "name": name,
+                    "port": port,
+                }
+            )

--- a/charms/katib-db-manager/metadata.yaml
+++ b/charms/katib-db-manager/metadata.yaml
@@ -26,3 +26,6 @@ requires:
   relational-db:
     interface: mysql_client
     limit: 1
+provides:
+  k8s-service-info:
+    interface: k8s-service

--- a/charms/katib-db-manager/requirements-unit.txt
+++ b/charms/katib-db-manager/requirements-unit.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements-unit.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via httpcore
 attrs==23.1.0
@@ -68,6 +70,10 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.2.0
     # via pytest
+pydantic==2.6.4
+    # via -r requirements.in
+pydantic-core==2.16.3
+    # via pydantic
 pyrsistent==0.19.3
     # via jsonschema
 pytest==7.4.0
@@ -98,6 +104,11 @@ tenacity==8.2.3
     # via charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
+typing-extensions==4.12.1
+    # via
+    #   annotated-types
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via requests
 websocket-client==1.6.1

--- a/charms/katib-db-manager/requirements.in
+++ b/charms/katib-db-manager/requirements.in
@@ -1,3 +1,10 @@
 charmed-kubeflow-chisme
 lightkube
 ops
+# This is a requirement from the k8s_service_info library
+# # pydantic>=2.7 requires rustc v1.76 or newer,
+# which is not available in the base OS this charm has at the moment (Ubuntu 20.04).
+# To avoid build-time errors, pydantic has to be pinned to a version that can be built
+# with the rustc version that the OS can provide.
+# Remove this pin when the base OS can install rustc v1.76 or newer.
+pydantic>=2.6,<2.7

--- a/charms/katib-db-manager/requirements.in
+++ b/charms/katib-db-manager/requirements.in
@@ -2,9 +2,6 @@ charmed-kubeflow-chisme
 lightkube
 ops
 # This is a requirement from the k8s_service_info library
-# # pydantic>=2.7 requires rustc v1.76 or newer,
-# which is not available in the base OS this charm has at the moment (Ubuntu 20.04).
-# To avoid build-time errors, pydantic has to be pinned to a version that can be built
-# with the rustc version that the OS can provide.
+# Pin due to https://github.com/canonical/bundle-kubeflow/issues/926
 # Remove this pin when the base OS can install rustc v1.76 or newer.
 pydantic>=2.6,<2.7

--- a/charms/katib-db-manager/requirements.txt
+++ b/charms/katib-db-manager/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via httpcore
 attrs==23.1.0
@@ -55,6 +57,10 @@ ordered-set==4.1.0
     # via deepdiff
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+pydantic==2.6.4
+    # via -r requirements.in
+pydantic-core==2.16.3
+    # via pydantic
 pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0.1
@@ -77,6 +83,11 @@ sniffio==1.3.0
     #   httpx
 tenacity==8.2.3
     # via charmed-kubeflow-chisme
+typing-extensions==4.12.1
+    # via
+    #   annotated-types
+    #   pydantic
+    #   pydantic-core
 urllib3==2.0.4
     # via requests
 websocket-client==1.6.1

--- a/charms/katib-db-manager/src/charm.py
+++ b/charms/katib-db-manager/src/charm.py
@@ -9,6 +9,7 @@ from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charmed_kubeflow_chisme.pebble import update_layer
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.mlops_libs.v0.k8s_service_info import KubernetesServiceInfoProvider
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from lightkube import ApiError
 from lightkube.generic_resource import load_in_cluster_generic_resources
@@ -81,6 +82,14 @@ class KatibDBManagerOperator(CharmBase):
             self,
             [port],
             service_name=f"{self.model.app.name}",
+        )
+
+        # KubernetesServiceInfoProvider for broadcasting the service information
+        self._k8s_svc_info_provider = KubernetesServiceInfoProvider(
+            charm=self,
+            name=self._container_name,
+            port=str(self._port),
+            refresh_event=self.on.config_changed,
         )
 
     @property

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -60,6 +60,7 @@ async def test_deploy_katib_charms(ops_test: OpsTest):
 
     # Relate to katib-db
     await ops_test.model.add_relation("katib-db-manager", "katib-db")
+    await ops_test.model.add_relation("katib-db-manager", "katib-controller")
 
     await ops_test.model.wait_for_idle(
         status="active",

--- a/tests/integration/test_katib_experiments.py
+++ b/tests/integration/test_katib_experiments.py
@@ -29,7 +29,6 @@ PROFILE_RESOURCE = create_global_resource(
 )
 TRAINING_OPERATOR = "training-operator"
 TRAINING_OPERATOR_CHANNEL = "latest/edge"
-TRAINING_OPERATOR_TRUST = True
 
 
 @pytest.fixture(scope="module")
@@ -46,7 +45,7 @@ async def training_operator(ops_test: OpsTest):
     await ops_test.model.deploy(
         entity_url=TRAINING_OPERATOR,
         channel=TRAINING_OPERATOR_CHANNEL,
-        trust=TRAINING_OPERATOR_TRUST,
+        trust=True,
     )
     await ops_test.model.wait_for_idle(
         apps=[TRAINING_OPERATOR], status="active", raise_on_blocked=False, timeout=60 * 5


### PR DESCRIPTION
This PR introduces a `k8s-service-info` between katib-controller and katib-db-manager. This addresses the issue below. Read the [summary comment](https://github.com/canonical/bundle-kubeflow/issues/893#issuecomment-2142022677) for a quick overview of the issue.

Note that this means that `katib-controller` will require a relation to `katib-db-manager` in order to start its pebble service, which we will need to introduce in the `latest/edge` bundle.

#### Testing

1. Deploy AKS cluster [following the guide](https://charmed-kubeflow.io/docs/deploy-charmed-kubeflow-to-aks). You can always check the [deploy-to-aks](https://github.com/canonical/bundle-kubeflow/blob/main/.github/workflows/deploy-to-aks.yaml) workflow for the commands the CI follows. Note that Juju 3.5 should be used but right now is broken thus 3.4 is probably a better option (didn't try this though myself). Another option could be using channel `3/stable` which points to 3.5.0 which is not broken (apart from the issue with kubeflow-dashboard which you can workaround by refreshing to upstream image).
2. Update the latest/edge `bundle.yaml` as follows
```diff
@@ -64,11 +64,12 @@ applications:
     _github_repo_branch: main
   katib-controller:
     charm: katib-controller
-    channel: latest/edge
+    channel: latest/edge/pr-185
     scale: 1
     trust: true
     _github_repo_name: katib-operators
     _github_repo_branch: main
+    base: ubuntu@20.04
   katib-db:
     charm: mysql-k8s
     channel: 8.0/edge
@@ -79,11 +80,12 @@ applications:
     _github_dependency_repo_branch: main
   katib-db-manager:
     charm: katib-db-manager
-    channel: latest/edge
+    channel: latest/edge/pr-185
     scale: 1
     trust: true
     _github_repo_name: katib-operators
     _github_repo_branch: main
+    base: ubuntu@20.04
   katib-ui:
     charm: katib-ui
     channel: latest/edge
@@ -297,6 +299,7 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-controller, katib-db-manager]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]

``` 
3. Deploy kubeflow using the tox environment tests are using as well
```shell
tox -e test_bundle_deployment-latest -- --model kubeflow --keep-models -vv -s
```
This uses the edited `bundle.yaml`

5. Create a notebook and run katib UAT

Closes canonical/bundle-kubeflow#893