### PR TITLE
chore: fix katib-controller integration test

### DIFF
--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -43,20 +43,8 @@ class TestCharm:
 
         Assert on the unit status.
         """
-        # Deploy dependencies katib-db-manager and katib-db which is a dependency of the latter.
-        # Building the charm as a temporary workaround since this PR introduces a new relation.
-        # Once this PR is merged, a follow-up PR will remove the following code
-        # and uncomment the line below.
-        db_manager_path = Path("../katib-db-manager")
-        db_manager_metadata = yaml.safe_load(Path(f"{db_manager_path}/metadata.yaml").read_text())
-        db_manager_image_path = db_manager_metadata["resources"]["oci-image"]["upstream-source"]
-        db_manager_charm = await ops_test.build_charm(db_manager_path)
-        await ops_test.model.deploy(
-            db_manager_charm, resources={"oci-image": db_manager_image_path}, trust=True
-        )
-        # await ops_test.model.deploy(
-        #     KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=True
-        # )
+        # Deploy dependency katib-db-manager
+        await ops_test.model.deploy(KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=True)
 
         charm_under_test = await ops_test.build_charm(".")
         image_path = METADATA["resources"]["oci-image"]["upstream-source"]


### PR DESCRIPTION
Follow up PR to #185
Tests can now deploy katib-db-manager with the `k8s-service-info` relation from `latest/edge`.

Ref canonical/bundle-kubeflow#893