### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track 0.16

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
 
       - run: |
@@ -110,7 +110,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           microk8s-addons: "dns storage rbac"
 
       - name: Run test


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944