### PR TITLE
chore: bump python-libjuju, pytest-operator and pytest from integrati…

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -6,6 +6,8 @@
 #
 anyio==4.0.0
     # via httpcore
+appnope==0.1.4
+    # via ipython
 asttokens==2.4.0
     # via stack-data
 backcall==0.2.0
@@ -63,7 +65,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==3.2.2
+juju==3.5.0.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -86,7 +88,9 @@ oauthlib==3.2.2
     #   kubernetes
     #   requests-oauthlib
 packaging==23.1
-    # via pytest
+    # via
+    #   juju
+    #   pytest
 paramiko==2.12.0
     # via juju
 parso==0.8.3
@@ -129,14 +133,14 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pytest==7.4.2
+pytest==8.0.2
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.35.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes


### PR DESCRIPTION
…on requirements

There seems to be an incompatibility issue between juju 3.4/stable (3.4.4 atm) and python-libjuju 3.2.x, which may be causing constant RPC disconnection issues (e.g. RPC: Automatic reconnect failed).
This commit bumps the version of python-libjuju to a more recent one, and also bumps pytest and pytest-operator as they are also kind of outdated.

Fixes #209