### PR TITLE
build: add rust toolchain and other build packages

### DIFF
--- a/charms/katib-ui/charmcraft.yaml
+++ b/charms/katib-ui/charmcraft.yaml
@@ -10,3 +10,4 @@ parts:
   charm:
     # Remove when pypa/setuptools_scm#713 gets fixed
     charm-python-packages: [setuptools==62.1.0, pip==22.0.4]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
Adding the rust toolchain and other dependencies to avoid issues at build time.

Part of canonical/bundle-kubeflow#989