### PR TITLE
chore: update python dependencies + pin pip

### DIFF
--- a/charms/katib-controller/requirements-fmt.txt
+++ b/charms/katib-controller/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/katib-controller/requirements-integration.txt
+++ b/charms/katib-controller/requirements-integration.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.0.0
-    # via httpcore
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.0
+anyio==4.5.2
+    # via httpx
+asttokens==3.0.0
     # via stack-data
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.3.3
+cachetools==5.5.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cryptography==42.0.8
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -40,28 +40,28 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-google-auth==2.30.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -69,7 +69,7 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.12.3
     # via ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -77,18 +77,18 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.5
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.30.0.8
+lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
@@ -102,17 +102,17 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.1
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 parso==0.8.4
     # via jedi
@@ -124,20 +124,20 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==5.27.1
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -156,20 +156,20 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.2.2
+pytest==8.3.4
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-integration.in
     #   juju
@@ -197,20 +197,17 @@ serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 stack-data==0.6.3
     # via ipython
-tenacity==8.4.1
+tenacity==9.0.0
     # via charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
@@ -224,10 +221,11 @@ typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -237,7 +235,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-controller/requirements-lint.txt
+++ b/charms/katib-controller/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/katib-controller/requirements-unit.txt
+++ b/charms/katib-controller/requirements-unit.txt
@@ -6,41 +6,58 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2024.2.2
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
-coverage==7.4.2
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-idna==3.6
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -48,15 +65,28 @@ jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.2
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.7
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
+macaroonbakery==1.3.4
+    # via juju
 markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -65,61 +95,122 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.2
-    # via pytest
+packaging==24.2
+    # via
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cosl
 pydantic-core==2.16.3
     # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.0.1
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-lazy-fixture
     #   pytest-mock
 pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-unit.in
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
 ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
     # via
-    #   anyio
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-tomli==2.0.1
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+tomli==2.2.1
     # via pytest
-typing-extensions==4.9.0
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
-    # via requests
-websocket-client==1.7.0
-    # via ops
-zipp==3.17.0
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-controller/requirements.txt
+++ b/charms/katib-controller/requirements.txt
@@ -6,51 +6,81 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2024.2.2
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-idna==3.6
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.2
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.7
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -58,45 +88,106 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cosl
 pydantic-core==2.16.3
     # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
 ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
     # via
-    #   anyio
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-typing-extensions==4.9.0
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.17.0
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-controller/tox.ini
+++ b/charms/katib-controller/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]

--- a/charms/katib-db-manager/requirements-fmt.txt
+++ b/charms/katib-db-manager/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/katib-db-manager/requirements-integration.txt
+++ b/charms/katib-db-manager/requirements-integration.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.0.0
-    # via httpcore
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.0
+anyio==4.5.2
+    # via httpx
+asttokens==3.0.0
     # via stack-data
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.3.3
+cachetools==5.5.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cryptography==42.0.8
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -40,28 +40,28 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-google-auth==2.30.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -69,7 +69,7 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.12.3
     # via ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -77,16 +77,16 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.5
     # via charmed-kubeflow-chisme
-lightkube-models==1.30.0.8
+lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
@@ -100,18 +100,18 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.1
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 parso==0.8.4
     # via jedi
@@ -123,20 +123,20 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==5.27.1
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -155,20 +155,20 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.2.2
+pytest==8.3.4
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-integration.in
     #   juju
@@ -196,20 +196,17 @@ serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 stack-data==0.6.3
     # via ipython
-tenacity==8.4.0
+tenacity==9.0.0
     # via charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
@@ -223,10 +220,11 @@ typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -236,7 +234,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-db-manager/requirements-lint.txt
+++ b/charms/katib-db-manager/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/katib-db-manager/requirements-unit.txt
+++ b/charms/katib-db-manager/requirements-unit.txt
@@ -6,43 +6,60 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
-coverage==7.3.0
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.7
     # via httpx
-httpx==0.24.1
+httpx==0.28.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -50,15 +67,28 @@ jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -67,56 +97,117 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
-    # via pytest
+packaging==24.2
+    # via
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.5.0
     # via pytest
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cosl
 pydantic-core==2.16.3
     # via pydantic
-pyrsistent==0.19.3
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.0
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-mock
-pytest-mock==3.11.1
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
     # via
-    #   anyio
-    #   httpcore
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-tomli==2.0.1
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+tomli==2.2.1
     # via pytest
-typing-extensions==4.12.1
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   annotated-types
+    #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-db-manager/requirements.txt
+++ b/charms/katib-db-manager/requirements.txt
@@ -6,51 +6,81 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.7
     # via httpx
-httpx==0.24.1
+httpx==0.28.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -58,44 +88,105 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cosl
 pydantic-core==2.16.3
     # via pydantic
-pyrsistent==0.19.3
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
     # via
-    #   anyio
-    #   httpcore
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-typing-extensions==4.12.1
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   annotated-types
+    #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-db-manager/tox.ini
+++ b/charms/katib-db-manager/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]

--- a/charms/katib-ui/requirements-fmt.txt
+++ b/charms/katib-ui/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/katib-ui/requirements-lint.txt
+++ b/charms/katib-ui/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/katib-ui/requirements.txt
+++ b/charms/katib-ui/requirements.txt
@@ -4,51 +4,83 @@
 #
 #    pip-compile requirements.in
 #
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.7
     # via httpx
-httpx==0.24.1
+httpx==0.28.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -56,38 +88,105 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyrsistent==0.19.3
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.10.3
+    # via cosl
+pydantic-core==2.27.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
     # via
-    #   anyio
-    #   httpcore
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+toposort==1.10
+    # via juju
 typing-extensions==4.12.2
-    # via cosl
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   juju
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/katib-ui/tox.ini
+++ b/charms/katib-ui/tox.ini
@@ -37,6 +37,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]

--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,53 +4,53 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.0.0
-    # via httpcore
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.0
+anyio==4.5.2
+    # via httpx
+asttokens==3.0.0
     # via stack-data
 backcall==0.2.0
     # via ipython
-bcrypt==4.0.1
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.3.1
+cachetools==5.5.0
     # via google-auth
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cryptography==41.0.3
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==1.2.0
+executing==2.1.0
     # via stack-data
-google-auth==2.22.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.7
     # via httpx
-httpx==0.24.1
+httpx==0.28.0
     # via lightkube
-hvac==1.2.0
+hvac==2.3.0
     # via juju
-idna==3.4
+idna==3.10
     # via
     #   anyio
     #   httpx
@@ -59,27 +59,27 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-jedi==0.19.0
+jedi==0.19.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via pytest-operator
-juju==3.5.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-kubernetes==27.2.0
+kubernetes==30.1.0
     # via juju
-lightkube==0.14.0
+lightkube==0.15.5
     # via -r requirements-integration.in
-lightkube-models==1.28.1.4
+lightkube-models==1.31.1.8
     # via lightkube
-macaroonbakery==1.3.1
+macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
@@ -87,41 +87,39 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.1
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==2.12.0
+paramiko==3.5.0
     # via juju
-parso==0.8.3
+parso==0.8.4
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==3.20.3
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.5.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.1
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pygments==2.16.1
+pygments==2.18.0
     # via ipython
-pyhcl==0.4.5
-    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -133,78 +131,73 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pytest==8.0.2
+pytest==8.3.4
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
+pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2023.3.post1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-integration.in
     #   juju
     #   kubernetes
     #   lightkube
     #   pytest-operator
-requests==2.31.0
+requests==2.32.3
     # via
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
 six==1.16.0
     # via
-    #   asttokens
-    #   google-auth
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   httpcore
-    #   httpx
-stack-data==0.6.2
+sniffio==1.3.1
+    # via anyio
+stack-data==0.6.3
     # via ipython
-tenacity==8.2.3
+tenacity==9.0.0
     # via -r requirements-integration.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.9.0
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
+    #   anyio
     #   ipython
+    #   juju
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==1.26.16
+urllib3==2.2.3
     # via
-    #   google-auth
     #   kubernetes
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.8.0
     # via kubernetes
-websockets==8.1
+websockets==13.1
     # via juju

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Update python dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1177