### PR TITLE
remove charmcraft pin to latest/candidate

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -85,7 +85,6 @@ jobs:
           provider: microk8s
           channel: 1.31-strict/stable
           juju-channel: 3.6/stable
-          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
 
       - run: |
           sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- -- --model testing"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,3 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release


### PR DESCRIPTION
Removes the charmcraft channel pin now that charmcraft 3.3 is [released to stable](https://snapcraft.io/charmcraft)