### PR TITLE
Use tox for lint checks

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -155,7 +155,7 @@ jobs:
         if: failure()
 
       - name: Upload charmcraft logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: /tmp/charmcraft-log-*

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -26,21 +26,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo apt update
-        sudo apt install python3-setuptools
-        sudo pip3 install black flake8
-
-    - name: Check black
-      run: black --check charms/*/src
-
-    - name: Check flake8
-      run: flake8 ./charms/*/src
+      - uses: actions/checkout@v4
+      - run: python3 -m pip install tox
+      - run: tox -e lint
 
   unit:
     name: Unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ allowlist_externals =
     bash
     find
     pip-compile
-commands = 
+commands =
     ; we must preserve the order of compilation, since each *.in file depends on some *.txt file.
     ; For example, requirements-unit.in depends on requirements.txt and we must compile first
     ; requirements.txt to ensure that requirements-unit.txt get the same dependency as the requirements.txt
@@ -56,6 +56,7 @@ commands =
     codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
       --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv \
       --skip {toxinidir}/./.mypy_cache \
+      --skip {toxinidir}/./charms/katib-controller/src/templates/webhooks.yaml.j2 \
       --skip {toxinidir}/./icon.svg --skip *.json.tmpl
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}


### PR DESCRIPTION
Closes https://github.com/canonical/katib-operators/issues/116

Bumped into it while working for https://github.com/canonical/katib-operators/issues/260

## Changes
- Uses the `tox` environment for linting, instead of pulling the dependencies in the action
- Updates the lint command to exclude on of the templates, that was messing with spell checking