### PR TITLE
chore: integrate katib-ui:v0.18.0-c84f19c rock

### DIFF
--- a/charms/katib-ui/metadata.yaml
+++ b/charms/katib-ui/metadata.yaml
@@ -15,7 +15,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflowkatib/katib-ui:v0.18.0-rc.0
+    upstream-source: docker.io/charmedkubeflow/katib-ui:v0.18.0-c84f19c
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Integrate katib-ui:v0.18.0-c84f19c rock in preparation for the 0.18 release