### PR TITLE
cherry-pick(fix): set constraints to setuptools-scm to avoid install loops from #296

### DIFF
--- a/charms/katib-controller/charmcraft.yaml
+++ b/charms/katib-controller/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/katib-controller/constraints.txt
+++ b/charms/katib-controller/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/katib-db-manager/charmcraft.yaml
+++ b/charms/katib-db-manager/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/katib-db-manager/constraints.txt
+++ b/charms/katib-db-manager/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/katib-ui/charmcraft.yaml
+++ b/charms/katib-ui/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/katib-ui/constraints.txt
+++ b/charms/katib-ui/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
Due to python/importlib_metadata#516, we need to set up constaints to the `setuptools-scm` to avoid install loops for these charms dependencies, as recommended by the charmcraft team (see https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428).

Fixes #293