### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/charms/katib-controller/requirements-integration.txt
+++ b/charms/katib-controller/requirements-integration.txt
@@ -28,7 +28,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -53,7 +53,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/katib-controller/tests/integration/charms_dependencies.py
+++ b/charms/katib-controller/tests/integration/charms_dependencies.py
@@ -1,0 +1,5 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+KATIB_DB_MANAGER = CharmSpec(charm="katib-db-manager", channel="latest/edge", trust=True)

--- a/charms/katib-controller/tests/integration/test_charm.py
+++ b/charms/katib-controller/tests/integration/test_charm.py
@@ -12,6 +12,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from charms_dependencies import KATIB_DB_MANAGER
 from lightkube.resources.core_v1 import ConfigMap
 from pytest_operator.plugin import OpsTest
 
@@ -20,8 +21,6 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
 KATIB_CONFIG = "katib-config"
-KATIB_DB_MANAGER = "katib-db-manager"
-KATIB_DB_MANAGER_CHANNEL = "latest/edge"
 KATIB_VERSION = "v0.18.0"
 TRIAL_TEMPLATE = "trial-template"
 EXPECTED_KATIB_CONFIG = {
@@ -62,7 +61,9 @@ class TestCharm:
         Assert on the unit status.
         """
         # Deploy dependency katib-db-manager
-        await ops_test.model.deploy(KATIB_DB_MANAGER, channel=KATIB_DB_MANAGER_CHANNEL, trust=True)
+        await ops_test.model.deploy(
+            KATIB_DB_MANAGER.charm, channel=KATIB_DB_MANAGER.channel, trust=KATIB_DB_MANAGER.trust
+        )
 
         entity_url = (
             await ops_test.build_charm(".")
@@ -79,7 +80,7 @@ class TestCharm:
             application_name=CHARM_NAME,
             trust=True,
         )
-        await ops_test.model.integrate(CHARM_NAME, KATIB_DB_MANAGER)
+        await ops_test.model.integrate(CHARM_NAME, KATIB_DB_MANAGER.charm)
 
         await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=300)
 

--- a/charms/katib-db-manager/requirements-integration.txt
+++ b/charms/katib-db-manager/requirements-integration.txt
@@ -28,7 +28,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -53,7 +53,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/katib-db-manager/tests/integration/charms_dependencies.py
+++ b/charms/katib-db-manager/tests/integration/charms_dependencies.py
@@ -1,0 +1,7 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+MYSQL_K8S = CharmSpec(
+    charm="mysql-k8s", channel="8.0/stable", config={"profile": "testing"}, trust=True
+)

--- a/charms/katib-db-manager/tests/integration/test_charm.py
+++ b/charms/katib-db-manager/tests/integration/test_charm.py
@@ -8,6 +8,7 @@ from charmed_kubeflow_chisme.testing import (
     assert_logging,
     deploy_and_assert_grafana_agent,
 )
+from charms_dependencies import MYSQL_K8S
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -15,11 +16,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "katib-db-manager"
-
 DB_APP_NAME = "katib-db"
-MYSQL = "mysql-k8s"
-MYSQL_CHANNEL = "8.0/stable"
-MYSQL_CONFIG = {"profile": "testing"}
 
 
 class TestCharm:
@@ -53,11 +50,11 @@ class TestCharm:
 
         # deploy mysql-k8s charm
         await ops_test.model.deploy(
-            entity_url=MYSQL,
+            entity_url=MYSQL_K8S.charm,
             application_name=DB_APP_NAME,
-            channel=MYSQL_CHANNEL,
-            config=MYSQL_CONFIG,
-            trust=True,
+            channel=MYSQL_K8S.channel,
+            config=MYSQL_K8S.config,
+            trust=MYSQL_K8S.trust,
         )
 
         await ops_test.model.wait_for_idle(

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -7,3 +7,4 @@ pytest
 pytest-operator
 pyyaml
 tenacity
+charmed-kubeflow-chisme

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -8,6 +8,8 @@ anyio==4.5.2
     # via httpx
 asttokens==3.0.0
     # via stack-data
+attrs==25.3.0
+    # via jsonschema
 backcall==0.2.0
     # via ipython
 backports-strenum==1.3.1
@@ -26,6 +28,8 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
+charmed-kubeflow-chisme==0.4.9
+    # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
 cryptography==44.0.0
@@ -34,6 +38,10 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
+deprecated==1.2.18
+    # via opentelemetry-api
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -47,7 +55,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10
@@ -55,6 +65,12 @@ idna==3.10
     #   anyio
     #   httpx
     #   requests
+importlib-metadata==8.5.0
+    # via
+    #   opentelemetry-api
+    #   ops
+importlib-resources==6.4.5
+    # via jsonschema
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
@@ -64,15 +80,22 @@ ipython==8.12.3
 jedi==0.19.2
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   charmed-kubeflow-chisme
+    #   pytest-operator
+jsonschema==4.17.3
+    # via serialized-data-interface
 juju==3.6.0.0
     # via
     #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
 lightkube==0.15.6
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
@@ -87,6 +110,14 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
+opentelemetry-api==1.32.1
+    # via ops
+ops==2.21.1
+    # via
+    #   charmed-kubeflow-chisme
+    #   serialized-data-interface
+ordered-set==4.1.0
+    # via deepdiff
 packaging==24.2
     # via
     #   juju
@@ -99,6 +130,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.48
@@ -131,6 +164,8 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyrsistent==0.20.0
+    # via jsonschema
 pytest==8.3.4
     # via
     #   -r requirements-integration.in
@@ -150,17 +185,26 @@ pyyaml==6.0.2
     #   juju
     #   kubernetes
     #   lightkube
+    #   ops
     #   pytest-operator
+    #   serialized-data-interface
 requests==2.32.3
     # via
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
+    #   serialized-data-interface
 requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruamel-yaml==0.18.10
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.8
+    # via ruamel-yaml
+serialized-data-interface==0.7.0
+    # via charmed-kubeflow-chisme
 six==1.17.0
     # via
     #   kubernetes
@@ -174,7 +218,9 @@ sniffio==1.3.1
 stack-data==0.6.3
     # via ipython
 tenacity==9.0.0
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 tomli==2.2.1
     # via
     #   ipdb
@@ -200,6 +246,14 @@ urllib3==2.2.3
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
-    # via kubernetes
+    # via
+    #   kubernetes
+    #   ops
 websockets==13.1
     # via juju
+wrapt==1.17.2
+    # via deprecated
+zipp==3.20.2
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -1,0 +1,10 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="latest/edge", trust=True)
+MYSQL_K8S = CharmSpec(
+    charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"}
+)
+TRAINING_OPERATOR = CharmSpec(charm="training-operator", channel="latest/edge", trust=True)

--- a/tests/integration/test_charms.py
+++ b/tests/integration/test_charms.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from charms_dependencies import ISTIO_PILOT, KUBEFLOW_PROFILES, MYSQL_K8S
 from pytest_operator.plugin import OpsTest
 
 BUILD_SUFFIX = "_ubuntu@20.04-amd64.charm"
@@ -24,18 +25,6 @@ DB_MANAGER_APP_NAME = DB_MANAGER_METADATA["name"]
 
 DB_APP_NAME = "katib-db"
 
-KUBEFLOW_PROFILES = "kubeflow-profiles"
-KUBEFLOW_PROFILES_CHANNEL = "latest/edge"
-KUBEFLOW_PROFILES_TRUST = True
-
-ISTIO_PILOT = "istio-pilot"
-ISTIO_PILOT_CHANNEL = "latest/edge"
-ISTIO_PILOT_TRUST = True
-
-MYSQL = "mysql-k8s"
-MYSQL_CHANNEL = "8.0/stable"
-MYSQL_CONFIG = {"profile": "testing"}
-MYSQL_TRUST = True
 
 logger = logging.getLogger(__name__)
 
@@ -75,11 +64,11 @@ async def test_deploy_katib_charms(ops_test: OpsTest, request):
 
     # Deploy katib-db
     await ops_test.model.deploy(
-        entity_url=MYSQL,
+        entity_url=MYSQL_K8S.charm,
         application_name=DB_APP_NAME,
-        channel=MYSQL_CHANNEL,
-        config=MYSQL_CONFIG,
-        trust=MYSQL_TRUST,
+        channel=MYSQL_K8S.channel,
+        config=MYSQL_K8S.config,
+        trust=MYSQL_K8S.trust,
     )
 
     # Relate to katib-db
@@ -96,17 +85,17 @@ async def test_deploy_katib_charms(ops_test: OpsTest, request):
 
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
-        entity_url=KUBEFLOW_PROFILES,
-        channel=KUBEFLOW_PROFILES_CHANNEL,
-        trust=KUBEFLOW_PROFILES_TRUST,
+        entity_url=KUBEFLOW_PROFILES.charm,
+        channel=KUBEFLOW_PROFILES.channel,
+        trust=KUBEFLOW_PROFILES.trust,
     )
 
     # The profile controller needs AuthorizationPolicies to create Profiles
     # Deploy istio-pilot to provide the k8s cluster with this CRD
     await ops_test.model.deploy(
-        entity_url=ISTIO_PILOT,
-        channel=ISTIO_PILOT_CHANNEL,
-        trust=ISTIO_PILOT_TRUST,
+        entity_url=ISTIO_PILOT.charm,
+        channel=ISTIO_PILOT.channel,
+        trust=ISTIO_PILOT.trust,
     )
 
     # Wait for everything to deploy

--- a/tests/integration/test_katib_experiments.py
+++ b/tests/integration/test_katib_experiments.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import lightkube
 import pytest
+from charms_dependencies import TRAINING_OPERATOR
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource, load_in_cluster_generic_resources
 from pytest_operator.plugin import OpsTest
@@ -27,8 +28,6 @@ PROFILE_RESOURCE = create_global_resource(
     kind="Profile",
     plural="profiles",
 )
-TRAINING_OPERATOR = "training-operator"
-TRAINING_OPERATOR_CHANNEL = "latest/edge"
 
 
 @pytest.fixture(scope="module")
@@ -43,12 +42,12 @@ def lightkube_client() -> lightkube.Client:
 async def training_operator(ops_test: OpsTest):
     """Deploy training-operator charm, and wait until it's active."""
     await ops_test.model.deploy(
-        entity_url=TRAINING_OPERATOR,
-        channel=TRAINING_OPERATOR_CHANNEL,
-        trust=True,
+        entity_url=TRAINING_OPERATOR.charm,
+        channel=TRAINING_OPERATOR.channel,
+        trust=TRAINING_OPERATOR.trust,
     )
     await ops_test.model.wait_for_idle(
-        apps=[TRAINING_OPERATOR], status="active", raise_on_blocked=False, timeout=60 * 5
+        apps=[TRAINING_OPERATOR.charm], status="active", raise_on_blocked=False, timeout=60 * 5
     )
 
 


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
