### PR TITLE
chore(ci): Setup the correct Python version in `tiobe_scan.yaml`

### DIFF
--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR:
- Renames `tiobe_scan.yml` to `tiobe_scan.yaml`. This is to make automation (such as replacing files in all workflow files) easier.
- Updates the `setup-python` action to use the new Python version (`3.12`).