### PR TITLE
fix: correct track output name in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ on:
         value: ${{ jobs.get-charm-paths-track.outputs.charm-paths }}
       track:
         description: Charmhub track determined from branch name
-        value: ${{ jobs.get-charm-paths-track.outputs.charm-channel }}
+        value: ${{ jobs.get-charm-paths-track.outputs.track }}
 
 jobs:
   get-charm-paths-track:


### PR DESCRIPTION
## Description

This PR fixes an issue in the CI workflow where the output reference was using the old name `charm-channel` instead of the correct `track` name.

## Changes

- Updated `.github/workflows/ci.yaml` to use the correct output reference: `value: ${{ jobs.get-charm-paths-track.outputs.track }}`

This is a follow-up fix to the data platform workflows v38 update.
