### PR TITLE
chore: update terraform modules channel to 0.19/stable

### DIFF
--- a/charms/katib-controller/terraform/variables.tf
+++ b/charms/katib-controller/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "base" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = "0.19/stable"
 }
 
 variable "config" {

--- a/charms/katib-db-manager/terraform/variables.tf
+++ b/charms/katib-db-manager/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "base" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = "0.19/stable"
 }
 
 variable "config" {

--- a/charms/katib-ui/terraform/variables.tf
+++ b/charms/katib-ui/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "base" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = "0.19/stable"
 }
 
 variable "config" {


### PR DESCRIPTION
Closes: https://github.com/canonical/katib-operators/issues/383