### PR TITLE
fix: remove unnecessary mounts

### DIFF
--- a/charms/katib-controller/metadata.yaml
+++ b/charms/katib-controller/metadata.yaml
@@ -17,7 +17,7 @@ resources:
     type: oci-image
     description: OCI image for katb-controller
     auto-fetch: true
-    upstream-source: docker.io/misohu/katib-controller:0.19.0
+    upstream-source: docker.io/charmedkubeflow/katib-controller:v0.19.0-698153e
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/katib-controller/src/charm.py
+++ b/charms/katib-controller/src/charm.py
@@ -52,7 +52,7 @@ K8S_RESOURCE_FILES = [
 KATIB_WEBHOOK_PORT = 8443
 CERTS_FOLDER = Path("/tmp/cert")
 KATIB_CONFIG_FILE = Path("src/templates/katib-config.yaml.j2")
-KATIB_CONFIG_DESTINTATION_PATH = "/katib-config/katib-config.yaml"
+KATIB_CONFIG_DESTINATION_PATH = "/katib-config/katib-config.yaml"
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ class KatibControllerOperator(CharmBase):
                     ),
                     ContainerFileTemplate(
                         source_template_path=KATIB_CONFIG_FILE,
-                        destination_path=KATIB_CONFIG_DESTINTATION_PATH,
+                        destination_path=KATIB_CONFIG_DESTINATION_PATH,
                         context_function=self._katib_config_context,
                     ),
                 ],


### PR DESCRIPTION
Closes: https://github.com/canonical/katib-operators/issues/389

note: the non-official OCI image used for intermediate testing was manually built from https://github.com/canonical/katib-rocks/pull/144 and it will be replaced with the official rock from that pull request once it is merged