### PR TITLE
feat: parametrize namespace webhooks templates

### DIFF
--- a/charms/katib-controller/src/templates/webhooks.yaml.j2
+++ b/charms/katib-controller/src/templates/webhooks.yaml.j2
@@ -12,7 +12,7 @@ webhooks:
       caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
-        namespace: kubeflow
+        namespace: {{ namespace }}
         path: /validate-experiment
     rules:
       - apiGroups:
@@ -38,7 +38,7 @@ webhooks:
       caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
-        namespace: kubeflow
+        namespace: {{ namespace }}
         path: /mutate-experiment
     rules:
       - apiGroups:
@@ -58,7 +58,7 @@ webhooks:
       caBundle: {{ ca_bundle }}
       service:
         name: katib-controller
-        namespace: kubeflow
+        namespace: {{ namespace }}
         path: /mutate-pod
     namespaceSelector:
       matchLabels:


### PR DESCRIPTION
This PR parametrizes the namespace in Katib webhook templates.
This PR is required to enable deployment of CKF on any namespace.