### PR TITLE
chore: remove lib checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,18 +58,6 @@ jobs:
           
           print(f"Track: {track}")
 
-  lib-check:
-    name: Check libraries
-    needs:
-      - get-charm-paths-track
-    strategy:
-      matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: ${{ matrix.charm }}
-
   lint:
     name: Lint
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR removes the `lib-check` job.

Ref: https://github.com/canonical/bundle-kubeflow/issues/1439