### PR TITLE
chore: pin charm dependencies in tests (track/0.19)

### DIFF
--- a/charms/katib-controller/tests/integration/charms_dependencies.py
+++ b/charms/katib-controller/tests/integration/charms_dependencies.py
@@ -2,4 +2,4 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-KATIB_DB_MANAGER = CharmSpec(charm="katib-db-manager", channel="latest/edge", trust=True)
+KATIB_DB_MANAGER = CharmSpec(charm="katib-db-manager", channel="0.19/edge", trust=True)

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -2,9 +2,9 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
-KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="latest/edge", trust=True)
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="1.28/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="1.10/edge", trust=True)
 MYSQL_K8S = CharmSpec(
     charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"}
 )
-TRAINING_OPERATOR = CharmSpec(charm="training-operator", channel="latest/edge", trust=True)
+TRAINING_OPERATOR = CharmSpec(charm="training-operator", channel="2.1/edge", trust=True)

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -3,7 +3,7 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="1.28/edge", trust=True)
-KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="1.10/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="2.0/edge", trust=True)
 MYSQL_K8S = CharmSpec(
     charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"}
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### Same-repo (pinned to `track/0.19`)
- `katib-db-manager`: `latest/edge` → `0.19/edge`

### External (resolved via Terraform Solutions track/1.11)
- `istio-pilot`: `latest/edge` → `1.28/edge`
- `kubeflow-profiles`: `latest/edge` → `2.0/edge` _(override)_
- `training-operator`: `latest/edge` → `2.1/edge`

### Unresolved (left unchanged)
- `mysql-k8s` (`8.0/stable`) — mysql-k8s not pinned in Solutions track/1.11

Refs: canonical/bundle-kubeflow#1379
