### PR TITLE
chore: add automatic backport tracks for KF 1.10 and 1.11

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,3 @@
+automatic_backport_tracks:
+  - track/0.19
+  - track/0.18


### PR DESCRIPTION
## Summary
This PR updates `automatic_backport_tracks.yaml` to the newest tracks that we use in our bundles.

Base issue: https://github.com/canonical/bundle-kubeflow/issues/1443