### PR TITLE
fix: handle multiple istio-ingress-route relations for `katib-ui`

### DIFF
--- a/charms/katib-ui/poetry.lock
+++ b/charms/katib-ui/poetry.lock
@@ -3376,4 +3376,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "c94774a7c9c7f9048626c28a4517b75d12d7b8304b6902c3f4e5fa9a8693aac3"
+content-hash = "564c9959ddddeb04bff74e85fe43ba959d1e545fefe9ca7ee5ed20c3b7f5ddc5"

--- a/charms/katib-ui/pyproject.toml
+++ b/charms/katib-ui/pyproject.toml
@@ -92,6 +92,7 @@ charmed-kubeflow-chisme = "^0.4.16"
 lightkube = "^0.15.6"
 pytest = "^8.3.4"
 pytest-operator = "^0.43.2"
+tenacity = "^9.0.0"
 
 [project]
 name = "katib-operators"

--- a/charms/katib-ui/src/charm.py
+++ b/charms/katib-ui/src/charm.py
@@ -212,6 +212,8 @@ class KatibUIOperator(CharmBase):
             ],
         )
         # Only submit config if we are a leader
+        # submit_config publishes this same config to every istio-ingress-route
+        # relation, so all related ingress providers are (re)configured at once.
         if self.unit.is_leader():
             self.ingress.submit_config(config)
 
@@ -274,11 +276,20 @@ class KatibUIOperator(CharmBase):
             )
 
     def _check_istio_relations(self):
-        """Check that both ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self.model.get_relation(ISTIO_INGRESS_ROUTE_RELATION)
-        sidecar_relation = self.model.get_relation(INGRESS_RELATION)
+        """Validate the charm's ingress relations are mutually exclusive.
 
-        if ambient_relation and sidecar_relation:
+        The charm supports both ambient ingress (via the '{ISTIO_INGRESS_ROUTE_RELATION}'
+        endpoint) and sidecar ingress (via the '{INGRESS_RELATION}' endpoint), but the two
+        cannot be used at the same time. Each endpoint may hold any number of relations,
+        so this inspects the full list of relations on each endpoint.
+
+        Raises:
+            CheckFailed: with BlockedStatus if relations exist on both endpoints.
+        """
+        ambient_relations = self.model.relations[ISTIO_INGRESS_ROUTE_RELATION]
+        sidecar_relations = self.model.relations[INGRESS_RELATION]
+
+        if ambient_relations and sidecar_relations:
             self.logger.error(
                 f"Both '{ISTIO_INGRESS_ROUTE_RELATION}' and '{INGRESS_RELATION}' relations "
                 "are present, remove one to unblock."

--- a/charms/katib-ui/tests/integration/test_charm_ambient.py
+++ b/charms/katib-ui/tests/integration/test_charm_ambient.py
@@ -6,18 +6,52 @@
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
+import tenacity
 import yaml
 from charmed_kubeflow_chisme.testing import (
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_path_reachable_through_ingress,
     deploy_and_integrate_service_mesh_charms,
 )
 from charms_dependencies import KATIB_DB_MANAGER
+from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
 from pytest_operator.plugin import OpsTest
 
 EXPECTED_RESPONSE_TEXT = "Frontend"
 HTTP_PATH = "/katib/"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by katib-ui (see charm._ambient_mesh_ingress).
+INGRESS_ROUTE_NAME = "http-route"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Path matched by the katib-ui HTTPRoute.
+INGRESS_ROUTE_PATH = HTTP_PATH
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
+RETRY_120_SECONDS = tenacity.Retrying(
+    stop=tenacity.stop_after_delay(120),
+    wait=tenacity.wait_fixed(2),
+    reraise=True,
+)
+
+
+@pytest_asyncio.fixture
+async def lightkube_client():
+    client = Client(field_manager="test")
+    yield client
 
 
 @pytest.mark.skip_if_deployed
@@ -72,8 +106,7 @@ async def test_deploy_and_relate_dependencies(ops_test: OpsTest):
     )
 
 
-@pytest.mark.abort_on_fail
-async def test_ui_is_accessible(ops_test: OpsTest):
+async def assert_ui_is_accessible(ops_test: OpsTest):
     """Verify that UI is accessible through the ingress gateway."""
     await assert_path_reachable_through_ingress(
         http_path=HTTP_PATH,
@@ -81,3 +114,90 @@ async def test_ui_is_accessible(ops_test: OpsTest):
         expected_content_type="text/html",
         expected_response_text=EXPECTED_RESPONSE_TEXT,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway before the second ingress."""
+    await assert_ui_is_accessible(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_second_ingress(ops_test: OpsTest):
+    """Deploy a second istio-ingress-k8s and relate it to katib-ui.
+
+    katib-ui must accept more than one istio-ingress-route relation without
+    erroring, so it should remain active after the second ingress is related.
+    """
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        application_name=SECOND_INGRESS_APP,
+        channel=INGRESS_CHANNEL,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [SECOND_INGRESS_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    await ops_test.model.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    await ops_test.model.wait_for_idle(
+        [APP_NAME, SECOND_INGRESS_APP],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=60 * 10,
+        idle_period=30,
+    )
+
+    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+
+async def test_httproute_attached_to_second_gateway(ops_test: OpsTest, lightkube_client: Client):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the katib-ui path to the katib-ui backend.
+    """
+    namespace = ops_test.model_name
+
+    expected_route_name = (
+        f"{APP_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_120_SECONDS:
+        with attempt:
+            httproute = lightkube_client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the katib-ui path to the katib-ui backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == INGRESS_ROUTE_PATH
+    assert rule["backendRefs"][0]["name"] == APP_NAME
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible_after_second_ingress(ops_test: OpsTest):
+    """Verify that UI is still accessible through the ingress gateway after the second ingress."""
+    await assert_ui_is_accessible(ops_test)

--- a/charms/katib-ui/tests/unit/test_operator.py
+++ b/charms/katib-ui/tests/unit/test_operator.py
@@ -4,7 +4,11 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
@@ -16,6 +20,9 @@ ISTIO_INGRESS_ROUTE_RELATION = "istio-ingress-route"
 INGRESS_RELATION = "ingress"
 ISTIO_GATEWAY_APP = "istio-gateway"
 ISTIO_INGRESS_K8S_APP = "istio-ingress-k8s"
+SECOND_ISTIO_INGRESS_K8S_APP = f"{ISTIO_INGRESS_K8S_APP}-2"
+HTTP_PATH = "/katib/"
+HTTP_SECTION_NAME = "http-80"
 K8S_SERVICE_INFO_RELATION = "k8s-service-info"
 DB_MANAGER_APP = "katib-db-manager"
 DB_MANAGER_SERVICE_NAME = "katib-db-manager"
@@ -299,18 +306,54 @@ def test_multiple_istio_ingress_route_relations(
     mocked_kubeflow_dashboard_links_requirer,
     mocked_load_in_cluster_generic_resources,
 ):
-    """Test that multiple istio-ingress-route relations are handled without erroring."""
-    harness.begin()
-
+    """Test the charm reconciles to active with more than one istio-ingress-route relation."""
     # Add more than one relation on the ambient ingress endpoint
     harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
-    harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, f"{ISTIO_INGRESS_K8S_APP}-2")
+    harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, SECOND_ISTIO_INGRESS_K8S_APP)
 
-    # Inspecting the full list of relations per endpoint must not raise even
-    # though there is more than one relation on a single endpoint.
-    harness.charm._check_istio_relations()
+    harness.begin_with_initial_hooks()
+    harness.charm.on.config_changed.emit()
 
-    assert not isinstance(harness.charm.model.unit.status, BlockedStatus)
+    # More than one relation on the istio-ingress-route endpoint must not block
+    # the charm; it should reconcile all the way to active.
+    assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+
+def test_each_istio_ingress_route_relation_receives_config(
+    harness,
+    mocked_resource_handler,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patcher,
+    mocked_service_mesh_consumer,
+    mocked_kubeflow_dashboard_links_requirer,
+    mocked_load_in_cluster_generic_resources,
+):
+    """Test that an HTTPRoute config is submitted to every istio-ingress-route relation."""
+    # Arrange (note: the real IstioIngressRouteRequirer is used here, not the mock,
+    # so we can assert on the config it writes to each relation databag).
+    rel_id_1 = harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
+    rel_id_2 = harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, SECOND_ISTIO_INGRESS_K8S_APP)
+
+    # Act
+    harness.begin()
+
+    # Assert
+    # Each relation's application databag should contain a valid config that
+    # defines the katib-ui HTTPRoute, proving the lib handles every ingress.
+    for rel_id in (rel_id_1, rel_id_2):
+        app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+        assert "config" in app_data
+
+        config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+        assert len(config.http_routes) == 1
+        http_route = config.http_routes[0]
+        assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+        assert http_route.matches[0].path.value == HTTP_PATH
+        assert http_route.backends[0].service == harness.charm.app.name
+        assert http_route.backends[0].port == harness.charm.model.config["port"]
+        # The route's parent (the Gateway listener referenced under parentRefs in
+        # the HTTPRouteSpec) should be the expected HTTP listener.
+        assert http_route.listener.name == HTTP_SECTION_NAME
 
 
 def test_ambient_ingress_configuration_leader_only(

--- a/charms/katib-ui/tests/unit/test_operator.py
+++ b/charms/katib-ui/tests/unit/test_operator.py
@@ -289,6 +289,30 @@ def test_both_istio_relations_blocked(
     )
 
 
+def test_multiple_istio_ingress_route_relations(
+    harness,
+    mocked_resource_handler,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patcher,
+    mocked_istio_ingress_route_requirer,
+    mocked_service_mesh_consumer,
+    mocked_kubeflow_dashboard_links_requirer,
+    mocked_load_in_cluster_generic_resources,
+):
+    """Test that multiple istio-ingress-route relations are handled without erroring."""
+    harness.begin()
+
+    # Add more than one relation on the ambient ingress endpoint
+    harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, ISTIO_INGRESS_K8S_APP)
+    harness.add_relation(ISTIO_INGRESS_ROUTE_RELATION, f"{ISTIO_INGRESS_K8S_APP}-2")
+
+    # Inspecting the full list of relations per endpoint must not raise even
+    # though there is more than one relation on a single endpoint.
+    harness.charm._check_istio_relations()
+
+    assert not isinstance(harness.charm.model.unit.status, BlockedStatus)
+
+
 def test_ambient_ingress_configuration_leader_only(
     harness,
     mocked_resource_handler,

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -14,7 +14,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_